### PR TITLE
fix NIP-70 things

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/server/CommandResult.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CommandResult.kt
@@ -12,6 +12,7 @@ data class CommandResult(val eventId: String, val result: Boolean, val descripti
         fun ok(event: Event) = CommandResult(event.id, true)
         fun duplicated(event: Event) = CommandResult(event.id, true, "duplicate:")
         fun invalid(event: Event, message: String) = CommandResult(event.id, false, "invalid: $message")
+        fun required(event: Event, message: String) = CommandResult(event.id, false, "auth-required: $message")
 
         fun mute(event: Event) = CommandResult(event.id, false, "mute: no one was listening to your ephemeral event and it wasn't handled in any way, it was ignored")
     }

--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -396,9 +396,7 @@ class CustomWebSocketServer(
     suspend fun innerProcessEvent(event: Event, connection: Connection?, shouldVerify: Boolean = true) {
         when (verifyEvent(event, connection, shouldVerify)) {
             VerificationResult.AuthRequiredForProtectedEvent -> {
-                if (Settings.authEnabled) {
-                    connection?.trySend(AuthResult.challenge(connection.authChallenge).toJson())
-                }
+                connection?.trySend(AuthResult.challenge(connection.authChallenge).toJson())
                 connection?.trySend(CommandResult.required(event, "this event may only be published by its author").toJson())
             }
             VerificationResult.InvalidId -> {

--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -399,7 +399,7 @@ class CustomWebSocketServer(
                 if (Settings.authEnabled) {
                     connection?.trySend(AuthResult.challenge(connection.authChallenge).toJson())
                 }
-                connection?.trySend(CommandResult.invalid(event, "auth-required: this event may only be published by its author").toJson())
+                connection?.trySend(CommandResult.required(event, "this event may only be published by its author").toJson())
             }
             VerificationResult.InvalidId -> {
                 connection?.trySend(

--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -315,7 +315,6 @@ class CustomWebSocketServer(
         }
 
         if (event.isProtected()) {
-            return VerificationResult.AuthRequiredForProtectedEvent
 
             if (connection?.users?.contains(event.pubKey) != true) {
                 Log.d(Citrine.TAG, "auth required for protected event ${event.id}")

--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -202,12 +202,6 @@ class CustomWebSocketServer(
 
                 "AUTH" -> {
                     val event = Event.fromJson(msgArray.get(1).toString())
-                    if (!Settings.authEnabled) {
-                        Log.d(Citrine.TAG, "auth disabled")
-                        connection?.trySend(CommandResult.invalid(event, "auth is disabled").toJson())
-                        return
-                    }
-
                     val exception = validateAuthEvent(event, connection?.authChallenge ?: "").exceptionOrNull()
                     if (exception != null) {
                         Log.d(Citrine.TAG, exception.message!!)
@@ -321,10 +315,7 @@ class CustomWebSocketServer(
         }
 
         if (event.isProtected()) {
-            if (!Settings.authEnabled) {
-                Log.d(Citrine.TAG, "auth disabled for protected event ${event.id}")
-                return VerificationResult.AuthRequiredForProtectedEvent
-            }
+            return VerificationResult.AuthRequiredForProtectedEvent
 
             if (connection?.users?.contains(event.pubKey) != true) {
                 Log.d(Citrine.TAG, "auth required for protected event ${event.id}")

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -10,7 +10,6 @@ import com.greenart7c3.citrine.database.toEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.jackson.EventMapper.Companion.mapper
 import com.vitorpamplona.quartz.nip40Expiration.isExpired
-import com.vitorpamplona.quartz.nip70ProtectedEvts.isProtected
 import kotlin.collections.isNotEmpty
 import kotlin.collections.joinToString
 
@@ -105,15 +104,6 @@ object EventRepository {
         events.forEach {
             val event = it.toEvent()
             if (!event.isExpired()) {
-                if (event.isProtected() && !Settings.authEnabled) {
-                    return@forEach
-                }
-                if (event.isProtected() && !subscription.connection.users.contains(event.pubKey)) {
-                    subscription.connection.trySend(AuthResult.challenge(subscription.connection.authChallenge).toJson())
-                    subscription.connection.trySend(CommandResult.required(event, "this event may only be queried by its author").toJson())
-                    return@forEach
-                }
-
                 Log.d(Citrine.TAG, "sending event ${event.id} subscription ${subscription.id} filter $filter")
                 subscription.connection.trySend(
                     subscription.objectMapper.writeValueAsString(

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -110,7 +110,7 @@ object EventRepository {
                 }
                 if (event.isProtected() && !subscription.connection.users.contains(event.pubKey)) {
                     subscription.connection.trySend(AuthResult.challenge(subscription.connection.authChallenge).toJson())
-                    subscription.connection.trySend(CommandResult.invalid(event, "auth-required: this event may only be queried by its author").toJson())
+                    subscription.connection.trySend(CommandResult.required(event, "this event may only be queried by its author").toJson())
                     return@forEach
                 }
 


### PR DESCRIPTION
- fix message prefix when sending an OK with "auth-required" (it was sending an "invalid" prefix)
- automatically send AUTH when getting a NIP-70 protected event even if AUTH is disabled on menu (because that menu option is about reading private things, not about accepting events, right?)
- allow reading NIP-70 protected events normally (they should not be treated differently with regards to reading)