### PR TITLE
dispatch events to subscriptions from the same connection it came from

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/server/EventSubscription.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventSubscription.kt
@@ -38,11 +38,6 @@ object EventSubscription {
         Citrine.getInstance().applicationScope.launch(Dispatchers.IO) {
             var sentEvent = false
             subscriptions.snapshot().values.forEach {
-                if (connection != null && it.subscription.connection.name == connection.name) {
-                    Log.d(Citrine.TAG, "skipping event to same connection")
-                    return@forEach
-                }
-
                 it.subscription.filters.forEach filter@{ filter ->
                     val event = dbEvent.toEvent()
                     if (filter.test(event)) {


### PR DESCRIPTION
Many apps assume they will receive in open subscriptions the same event they just published.
Jumble is the one I was testing in right now, but I'm pretty sure I've seen code like that many other times.