### PR TITLE
allow localhost access to bypass nip70 checks

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -315,9 +315,10 @@ class CustomWebSocketServer(
         }
 
         if (event.isProtected()) {
-            return VerificationResult.AuthRequiredForProtectedEvent
+            val remoteHost = connection?.session?.call?.request?.local?.remoteHost
+            val isLocalHost = remoteHost in listOf("127.0.0.1", "localhost", "::1", "0:0:0:0:0:0:0:1")
 
-            if (connection?.users?.contains(event.pubKey) != true) {
+            if (!isLocalHost && connection?.users?.contains(event.pubKey) != true) {
                 Log.d(Citrine.TAG, "auth required for protected event ${event.id}")
                 return VerificationResult.AuthRequiredForProtectedEvent
             }


### PR DESCRIPTION
This is necessary for syncing between different Citrine relays shared via Samiz while still preventing these local events from leaking to other relays through other clients.

Not ideal, but probably good enough so far.

I'm not sure, but I think specifically distinguishing Samiz (or similar apps) would be better in the future if possible: https://github.com/KoalaSat/samiz/issues/17