### PR TITLE
Add database upgrade progress notification and UI indicator

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/database/AppDatabase.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/AppDatabase.kt
@@ -1,6 +1,7 @@
 package com.greenart7c3.citrine.database
 
 import android.content.Context
+import android.database.sqlite.SQLiteDatabase
 import android.util.Log
 import androidx.room.Database
 import androidx.room.Room
@@ -11,6 +12,8 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import com.greenart7c3.citrine.BuildConfig
 import com.greenart7c3.citrine.Citrine
 import java.util.concurrent.Executors
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @Database(
     entities = [EventEntity::class, TagEntity::class, EventFTS::class],
@@ -24,7 +27,31 @@ abstract class AppDatabase : RoomDatabase() {
         @Volatile
         private var database: AppDatabase? = null
 
+        private val _isDatabaseUpgrading = MutableStateFlow(false)
+        val isDatabaseUpgrading: StateFlow<Boolean> = _isDatabaseUpgrading
+
+        private const val TARGET_VERSION = 11
+
+        private fun checkNeedsMigration(context: Context): Boolean {
+            val dbFile = context.getDatabasePath("citrine_database")
+            if (!dbFile.exists()) return false
+            return try {
+                SQLiteDatabase.openDatabase(dbFile.path, null, SQLiteDatabase.OPEN_READONLY).use { db ->
+                    db.version > 0 && db.version < TARGET_VERSION
+                }
+            } catch (e: Exception) {
+                Log.w(Citrine.TAG, "Could not check database version", e)
+                false
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase = database ?: synchronized(this) {
+            if (database != null) return database!!
+
+            if (checkNeedsMigration(context)) {
+                _isDatabaseUpgrading.value = true
+            }
+
             val executor = Executors.newCachedThreadPool()
             val transactionExecutor = Executors.newCachedThreadPool()
 
@@ -50,6 +77,7 @@ abstract class AppDatabase : RoomDatabase() {
                     override fun onOpen(db: SupportSQLiteDatabase) {
                         super.onOpen(db)
                         db.execSQL("PRAGMA cache_size=-32000;")
+                        _isDatabaseUpgrading.value = false
                     }
                 })
                 .build()

--- a/app/src/main/java/com/greenart7c3/citrine/service/WebSocketServerService.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/WebSocketServerService.kt
@@ -145,6 +145,35 @@ class WebSocketServerService : Service() {
             100000,
         )
 
+        scope.launch {
+            AppDatabase.isDatabaseUpgrading.collect { isUpgrading ->
+                val notificationManager = NotificationManagerCompat.from(this@WebSocketServerService)
+                if (isUpgrading) {
+                    val channel = NotificationChannelCompat.Builder(
+                        "citrine",
+                        NotificationManagerCompat.IMPORTANCE_DEFAULT,
+                    )
+                        .setName("Citrine")
+                        .build()
+                    notificationManager.createNotificationChannel(channel)
+
+                    val notification = NotificationCompat.Builder(this@WebSocketServerService, "citrine")
+                        .setContentTitle(getString(R.string.app_name_release))
+                        .setContentText(getString(R.string.upgrading_database))
+                        .setSmallIcon(R.drawable.ic_notification)
+                        .setOngoing(true)
+                        .setOnlyAlertOnce(true)
+                        .build()
+
+                    if (ActivityCompat.checkSelfPermission(this@WebSocketServerService, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
+                        notificationManager.notify(3, notification)
+                    }
+                } else {
+                    notificationManager.cancel(3)
+                }
+            }
+        }
+
         Log.d(Citrine.TAG, "Starting WebSocket server")
         // Start the WebSocket server
         CustomWebSocketService.server = CustomWebSocketServer(

--- a/app/src/main/java/com/greenart7c3/citrine/ui/HomeScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/HomeScreen.kt
@@ -53,6 +53,7 @@ import com.anggrayudi.storage.SimpleStorageHelper
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.R
 import com.greenart7c3.citrine.database.AppDatabase
+import com.greenart7c3.citrine.database.AppDatabase.Companion.isDatabaseUpgrading
 import com.greenart7c3.citrine.server.Settings
 import com.greenart7c3.citrine.service.CustomWebSocketService
 import com.greenart7c3.citrine.service.LocalPreferences
@@ -97,6 +98,7 @@ fun HomeScreen(
         }
 
         val state = homeViewModel.state.collectAsStateWithLifecycle()
+        val isUpgradingDatabase = isDatabaseUpgrading.collectAsStateWithLifecycle()
         var deleteAllDialog by remember { mutableStateOf(false) }
         var showDialog by remember { mutableStateOf(false) }
         var showAutoBackupDialog by remember { mutableStateOf(false) }
@@ -296,7 +298,10 @@ fun HomeScreen(
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            if (state.value.loading) {
+            if (isUpgradingDatabase.value) {
+                CircularProgressIndicator()
+                Text(stringResource(R.string.upgrading_database))
+            } else if (state.value.loading) {
                 CircularProgressIndicator()
             } else {
                 val isStarted = homeViewModel.state.value.service?.isStarted() ?: false

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name_release">Citrine</string>
+    <string name="upgrading_database">Upgrading database, please wait…</string>
     <string name="app_name_debug">Citrine Debug</string>
     <string name="no_follow_list_found">No follow list found</string>
     <string name="no_relays_found">No relays found</string>


### PR DESCRIPTION
## Summary
This PR adds user-facing feedback during database migrations by displaying a notification and UI indicator while the database is being upgraded.

## Key Changes
- **AppDatabase.kt**: 
  - Added `isDatabaseUpgrading` StateFlow to track database migration status
  - Implemented `checkNeedsMigration()` to detect if the database needs upgrading before initialization
  - Set `_isDatabaseUpgrading` to `true` when migration is detected and `false` when the database is ready
  - Added target version constant (v11) for migration detection

- **WebSocketServerService.kt**:
  - Added a coroutine that collects database upgrade state changes
  - Displays an ongoing notification with "Upgrading database, please wait…" message when migration is in progress
  - Automatically dismisses the notification when upgrade completes
  - Includes proper permission checks for POST_NOTIFICATIONS

- **HomeScreen.kt**:
  - Integrated database upgrade state into the UI
  - Shows a loading spinner and "Upgrading database, please wait…" message during migration
  - Prioritizes database upgrade indicator over regular loading state

- **strings.xml**:
  - Added new string resource for the upgrade message

## Implementation Details
- Uses Room's `onOpen()` callback to signal when the database is ready
- Checks database version before Room initialization to detect migrations early
- Notification uses channel ID "citrine" with default importance
- UI state is managed reactively through StateFlow collection

https://claude.ai/code/session_0182eNVWawPeXpuUuvpteLpv