### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,6 +5,9 @@ on:
     tags:
     - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
This PR adds explicit permission declarations to all GitHub Actions workflows to follow security best practices and improve workflow transparency.

## Key Changes
- **crowdin.yml**: Added `contents: write` and `pull-requests: write` permissions to support Crowdin synchronization operations
- **build.yml**: Added `contents: read` permission for the build workflow
- **create-release.yml**: Added `contents: write` permission for the release deployment workflow

## Implementation Details
These permission declarations follow the principle of least privilege by explicitly specifying only the permissions each workflow requires. This improves security by:
- Preventing workflows from requesting unnecessary permissions by default
- Making permission requirements transparent and auditable
- Reducing the attack surface if a workflow is compromised

Each workflow now declares only the minimum permissions needed for its specific operations.

https://claude.ai/code/session_01UkvZn1V6SxJvK5NydwihrS