### PR TITLE
Add pie chart visualization to database info view

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/ui/components/DatabaseInfo.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/components/DatabaseInfo.kt
@@ -1,13 +1,16 @@
 package com.greenart7c3.citrine.ui.components
 
 import android.util.Log
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -16,6 +19,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -25,6 +29,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -37,10 +43,93 @@ import androidx.navigation.NavController
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.R
 import com.greenart7c3.citrine.database.AppDatabase
+import com.greenart7c3.citrine.database.EventDao
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+
+private val pieColors = listOf(
+    Color(0xFF4E79A7),
+    Color(0xFFF28E2B),
+    Color(0xFFE15759),
+    Color(0xFF76B7B2),
+    Color(0xFF59A14F),
+    Color(0xFFEDC948),
+    Color(0xFFB07AA1),
+    Color(0xFFFF9DA7),
+    Color(0xFF9C755F),
+    Color(0xFFBAB0AC),
+    Color(0xFF8CD17D),
+)
+
+private data class PieSlice(val label: String, val count: Int, val color: Color)
+
+private fun buildPieSlices(events: List<EventDao.CountResult>): List<PieSlice> {
+    val sorted = events.sortedByDescending { it.count }
+    val top = sorted.take(10)
+    val otherCount = sorted.drop(10).sumOf { it.count }
+    val slices = top.mapIndexed { i, r ->
+        PieSlice("Kind ${r.kind}", r.count, pieColors[i % pieColors.size])
+    }.toMutableList()
+    if (otherCount > 0) {
+        slices.add(PieSlice("Other", otherCount, pieColors[10 % pieColors.size]))
+    }
+    return slices
+}
+
+@Composable
+private fun PieChart(slices: List<PieSlice>, modifier: Modifier = Modifier) {
+    val total = slices.sumOf { it.count }.toFloat()
+    if (total == 0f) return
+
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val diameter = minOf(size.width, size.height)
+            val topLeft = Offset(
+                (size.width - diameter) / 2f,
+                (size.height - diameter) / 2f,
+            )
+            val arcSize = Size(diameter, diameter)
+            var startAngle = -90f
+            slices.forEach { slice ->
+                val sweep = (slice.count / total) * 360f
+                drawArc(
+                    color = slice.color,
+                    startAngle = startAngle,
+                    sweepAngle = sweep,
+                    useCenter = true,
+                    topLeft = topLeft,
+                    size = arcSize,
+                )
+                startAngle += sweep
+            }
+        }
+    }
+}
+
+@Composable
+private fun PieLegend(slices: List<PieSlice>, total: Int) {
+    val onSurface = MaterialTheme.colorScheme.onSurface
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        slices.forEach { slice ->
+            val pct = if (total > 0) slice.count * 100f / total else 0f
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                Canvas(modifier = Modifier.size(12.dp)) {
+                    drawCircle(color = slice.color)
+                }
+                Text(
+                    text = "${slice.label}: ${slice.count} (${"%.1f".format(pct)}%)",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = onSurface,
+                )
+            }
+        }
+    }
+}
 
 class DatabaseInfoViewModelFactory(
     private val database: AppDatabase,
@@ -120,13 +209,34 @@ fun DatabaseInfo(
         )
     }
 
+    val slices = remember(events) { buildPieSlices(events) }
+    val total = events.sumOf { it.count }
+
     Column(
         modifier
             .fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(stringResource(R.string.total, events.sumOf { it.count }))
+        Text(stringResource(R.string.total, total))
         Spacer(modifier = Modifier.padding(4.dp))
+
+        if (slices.isNotEmpty()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                PieChart(
+                    slices = slices,
+                    modifier = Modifier.size(160.dp),
+                )
+                PieLegend(slices = slices, total = total)
+            }
+            Spacer(modifier = Modifier.padding(4.dp))
+        }
+
         LazyColumn(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/greenart7c3/citrine/ui/components/DatabaseInfo.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/components/DatabaseInfo.kt
@@ -67,8 +67,8 @@ private data class PieSlice(val label: String, val count: Int, val color: Color)
 
 private fun buildPieSlices(events: List<EventDao.CountResult>): List<PieSlice> {
     val sorted = events.sortedByDescending { it.count }
-    val top = sorted.take(10)
-    val otherCount = sorted.drop(10).sumOf { it.count }
+    val top = sorted.take(9)
+    val otherCount = sorted.drop(9).sumOf { it.count }
     val slices = top.mapIndexed { i, r ->
         PieSlice("Kind ${r.kind}", r.count, pieColors[i % pieColors.size])
     }.toMutableList()


### PR DESCRIPTION
## Summary
Added a pie chart visualization to the DatabaseInfo composable to display the distribution of event kinds in the database. The chart shows the top 10 event kinds with an "Other" category for remaining kinds, along with a legend displaying counts and percentages.

## Key Changes
- **New composables:**
  - `PieChart`: Renders a pie chart using Canvas with customizable slices
  - `PieLegend`: Displays a legend with color indicators, labels, counts, and percentages for each slice

- **Helper functions and data:**
  - `buildPieSlices()`: Transforms event count data into pie slices, grouping the top 10 kinds and aggregating the rest into an "Other" category
  - `PieSlice` data class: Represents a single pie slice with label, count, and color
  - `pieColors`: Predefined color palette (11 colors) for consistent pie slice coloring

- **UI Integration:**
  - Added pie chart and legend display in the DatabaseInfo view when event data is available
  - Chart is displayed in a Row layout with the pie chart (160dp) on the left and legend on the right
  - Maintains existing total event count display above the chart

## Notable Implementation Details
- The pie chart uses Canvas drawing for efficient rendering of arcs
- Colors are cycled through the palette if there are more than 11 slices
- The legend shows percentages formatted to one decimal place
- The visualization only displays when there is event data available
- Uses Material Design 3 theming for legend text styling

https://claude.ai/code/session_01FiPeKLNePqEJrwK2Sq8gEZ