### PR TITLE
Optimize event subscription performance with JSON caching and query semaphore

### DIFF
--- a/app/schemas/com.greenart7c3.citrine.database.AppDatabase/12.json
+++ b/app/schemas/com.greenart7c3.citrine.database.AppDatabase/12.json
@@ -1,0 +1,273 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "a9228f6e9fa5fde93bbd8b502d3e82b3",
+    "entities": [
+      {
+        "tableName": "EventEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `pubkey` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `kind` INTEGER NOT NULL, `content` TEXT NOT NULL, `sig` TEXT NOT NULL, `json` TEXT NOT NULL, `expiresAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pubkey",
+            "columnName": "pubkey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sig",
+            "columnName": "sig",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "idx_event_pubkey_created_id",
+            "unique": false,
+            "columnNames": [
+              "pubkey",
+              "createdAt",
+              "id"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_event_pubkey_created_id` ON `${TABLE_NAME}` (`pubkey` ASC, `createdAt` DESC, `id` ASC)"
+          },
+          {
+            "name": "idx_event_kind_created_id",
+            "unique": false,
+            "columnNames": [
+              "kind",
+              "createdAt",
+              "id"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_event_kind_created_id` ON `${TABLE_NAME}` (`kind` ASC, `createdAt` DESC, `id` ASC)"
+          },
+          {
+            "name": "idx_event_created_id",
+            "unique": false,
+            "columnNames": [
+              "createdAt",
+              "id"
+            ],
+            "orders": [
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_event_created_id` ON `${TABLE_NAME}` (`createdAt` DESC, `id` ASC)"
+          },
+          {
+            "name": "idx_event_pubkey_kind_created_id",
+            "unique": false,
+            "columnNames": [
+              "pubkey",
+              "kind",
+              "createdAt",
+              "id"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_event_pubkey_kind_created_id` ON `${TABLE_NAME}` (`pubkey` ASC, `kind` ASC, `createdAt` DESC, `id` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "TagEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pk` INTEGER PRIMARY KEY AUTOINCREMENT, `pkEvent` TEXT, `position` INTEGER NOT NULL, `col0Name` TEXT, `col1Value` TEXT, `col2Differentiator` TEXT, `col3Amount` TEXT, `col4Plus` TEXT NOT NULL, `kind` INTEGER NOT NULL, FOREIGN KEY(`pkEvent`) REFERENCES `EventEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "pk",
+            "columnName": "pk",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pkEvent",
+            "columnName": "pkEvent",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "col0Name",
+            "columnName": "col0Name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "col1Value",
+            "columnName": "col1Value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "col2Differentiator",
+            "columnName": "col2Differentiator",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "col3Amount",
+            "columnName": "col3Amount",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "col4Plus",
+            "columnName": "col4Plus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "pk"
+          ]
+        },
+        "indices": [
+          {
+            "name": "tags_by_pk_event",
+            "unique": false,
+            "columnNames": [
+              "pkEvent"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `tags_by_pk_event` ON `${TABLE_NAME}` (`pkEvent`)"
+          },
+          {
+            "name": "tags_by_tags_on_person_or_events",
+            "unique": false,
+            "columnNames": [
+              "col0Name",
+              "col1Value"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `tags_by_tags_on_person_or_events` ON `${TABLE_NAME}` (`col0Name`, `col1Value`)"
+          },
+          {
+            "name": "tags_by_kind_tags_on_person_or_events",
+            "unique": false,
+            "columnNames": [
+              "kind",
+              "col0Name",
+              "col1Value",
+              "pkEvent"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `tags_by_kind_tags_on_person_or_events` ON `${TABLE_NAME}` (`kind`, `col0Name`, `col1Value`, `pkEvent`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "EventEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pkEvent"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "event_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`content` TEXT NOT NULL, content=`EventEntity`)",
+        "fields": [
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "EventEntity",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_event_fts_BEFORE_UPDATE BEFORE UPDATE ON `EventEntity` BEGIN DELETE FROM `event_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_event_fts_BEFORE_DELETE BEFORE DELETE ON `EventEntity` BEGIN DELETE FROM `event_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_event_fts_AFTER_UPDATE AFTER UPDATE ON `EventEntity` BEGIN INSERT INTO `event_fts`(`docid`, `content`) VALUES (NEW.`rowid`, NEW.`content`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_event_fts_AFTER_INSERT AFTER INSERT ON `EventEntity` BEGIN INSERT INTO `event_fts`(`docid`, `content`) VALUES (NEW.`rowid`, NEW.`content`); END"
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a9228f6e9fa5fde93bbd8b502d3e82b3')"
+    ]
+  }
+}

--- a/app/schemas/com.greenart7c3.citrine.database.HistoryDatabase/11.json
+++ b/app/schemas/com.greenart7c3.citrine.database.HistoryDatabase/11.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 11,
-    "identityHash": "d6845f839ecfd087ba5f24a376ef4d60",
+    "identityHash": "396296be0412d983e45d6af238f776a2",
     "entities": [
       {
         "tableName": "EventEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `pubkey` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `kind` INTEGER NOT NULL, `content` TEXT NOT NULL, `sig` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `pubkey` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `kind` INTEGER NOT NULL, `content` TEXT NOT NULL, `sig` TEXT NOT NULL, `json` TEXT NOT NULL, `expiresAt` INTEGER, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -43,6 +43,17 @@
             "columnName": "sig",
             "affinity": "TEXT",
             "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER"
           }
         ],
         "primaryKey": {
@@ -223,7 +234,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd6845f839ecfd087ba5f24a376ef4d60')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '396296be0412d983e45d6af238f776a2')"
     ]
   }
 }

--- a/app/src/main/java/com/greenart7c3/citrine/database/AppDatabase.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/AppDatabase.kt
@@ -91,7 +91,7 @@ abstract class AppDatabase : RoomDatabase() {
                             val delegateField = db.javaClass.getDeclaredField("delegate")
                             delegateField.isAccessible = true
                             val sqliteDb = delegateField.get(db) as? SQLiteDatabase
-                            if (sqliteDb != null && sqliteDb.isWriteAheadLoggingEnabled) {
+                            if (sqliteDb != null) {
                                 val method = SQLiteDatabase::class.java.getDeclaredMethod(
                                     "setMaxConnectionPoolSize",
                                     Int::class.java,

--- a/app/src/main/java/com/greenart7c3/citrine/database/AppDatabase.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/AppDatabase.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.StateFlow
 
 @Database(
     entities = [EventEntity::class, TagEntity::class, EventFTS::class],
-    version = 11,
+    version = 12,
 )
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
@@ -30,7 +30,7 @@ abstract class AppDatabase : RoomDatabase() {
         private val _isDatabaseUpgrading = MutableStateFlow(false)
         val isDatabaseUpgrading: StateFlow<Boolean> = _isDatabaseUpgrading
 
-        private const val TARGET_VERSION = 11
+        private const val TARGET_VERSION = 12
 
         private fun checkNeedsMigration(context: Context): Boolean {
             val dbFile = context.getDatabasePath("citrine_database")
@@ -75,6 +75,7 @@ abstract class AppDatabase : RoomDatabase() {
                 .addMigrations(MIGRATION_8_9)
                 .addMigrations(MIGRATION_9_10)
                 .addMigrations(MIGRATION_10_11)
+                .addMigrations(MIGRATION_11_12)
                 .addCallback(object : Callback() {
                     override fun onOpen(db: SupportSQLiteDatabase) {
                         super.onOpen(db)
@@ -83,25 +84,6 @@ abstract class AppDatabase : RoomDatabase() {
                         db.execSQL("PRAGMA cache_size=-32000;")
                         db.execSQL("PRAGMA temp_store=MEMORY;")
                         db.query("PRAGMA mmap_size=268435456").close()
-                        // Increase WAL reader pool beyond the default of 2 so that
-                        // concurrent subscription queries don't serialize on connections.
-                        // FrameworkSQLiteDatabase wraps the real SQLiteDatabase in "delegate";
-                        // setMaxConnectionPoolSize is a hidden API so we reach it via reflection.
-                        try {
-                            val delegateField = db.javaClass.getDeclaredField("delegate")
-                            delegateField.isAccessible = true
-                            val sqliteDb = delegateField.get(db) as? SQLiteDatabase
-                            if (sqliteDb != null) {
-                                val method = SQLiteDatabase::class.java.getDeclaredMethod(
-                                    "setMaxConnectionPoolSize",
-                                    Int::class.java,
-                                )
-                                method.isAccessible = true
-                                method.invoke(sqliteDb, numCores)
-                            }
-                        } catch (e: Exception) {
-                            Log.w(Citrine.TAG, "Could not expand WAL connection pool", e)
-                        }
                         _isDatabaseUpgrading.value = false
                     }
                 })
@@ -143,6 +125,7 @@ abstract class HistoryDatabase : RoomDatabase() {
                 .addMigrations(MIGRATION_8_9)
                 .addMigrations(MIGRATION_9_10)
                 .addMigrations(MIGRATION_10_11)
+                .addMigrations(MIGRATION_11_12)
                 .addCallback(object : Callback() {
                     override fun onOpen(db: SupportSQLiteDatabase) {
                         super.onOpen(db)
@@ -235,6 +218,15 @@ val MIGRATION_10_11 = object : Migration(10, 11) {
         db.execSQL("DROP TABLE IF EXISTS `event_fts` ")
         db.execSQL("CREATE VIRTUAL TABLE IF NOT EXISTS `event_fts` USING FTS4(content, content=`EventEntity`)")
         db.execSQL("INSERT INTO `event_fts` (`event_fts`) VALUES ('rebuild')")
+    }
+}
+
+/** Adds pre-serialized JSON cache and NIP-40 expiration columns to EventEntity.
+ *  Existing rows get empty json (fall back to ByteWriter path) and null expiresAt. */
+val MIGRATION_11_12 = object : Migration(11, 12) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `EventEntity` ADD COLUMN `json` TEXT NOT NULL DEFAULT ''")
+        db.execSQL("ALTER TABLE `EventEntity` ADD COLUMN `expiresAt` INTEGER DEFAULT NULL")
     }
 }
 

--- a/app/src/main/java/com/greenart7c3/citrine/database/AppDatabase.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/AppDatabase.kt
@@ -62,6 +62,7 @@ abstract class AppDatabase : RoomDatabase() {
                 "citrine_database",
             )
 //                .setQueryCallback(AppDatabaseCallback(), Executors.newSingleThreadExecutor())
+                .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
                 .setQueryExecutor(executor)
                 .setTransactionExecutor(transactionExecutor)
                 .addMigrations(MIGRATION_1_2)
@@ -77,8 +78,7 @@ abstract class AppDatabase : RoomDatabase() {
                 .addCallback(object : Callback() {
                     override fun onOpen(db: SupportSQLiteDatabase) {
                         super.onOpen(db)
-                        // journal_mode and mmap_size return a result row, so use query() not execSQL()
-                        db.query("PRAGMA journal_mode=WAL").close()
+                        // mmap_size returns a result row, so use query() not execSQL()
                         db.execSQL("PRAGMA synchronous=NORMAL;")
                         db.execSQL("PRAGMA cache_size=-32000;")
                         db.execSQL("PRAGMA temp_store=MEMORY;")
@@ -113,6 +113,7 @@ abstract class HistoryDatabase : RoomDatabase() {
                 "citrine_history_database",
             )
 //                .setQueryCallback(AppDatabaseCallback(), Executors.newSingleThreadExecutor())
+                .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
                 .addMigrations(MIGRATION_1_2)
                 .addMigrations(MIGRATION_2_3)
                 .addMigrations(MIGRATION_3_4)
@@ -126,7 +127,6 @@ abstract class HistoryDatabase : RoomDatabase() {
                 .addCallback(object : Callback() {
                     override fun onOpen(db: SupportSQLiteDatabase) {
                         super.onOpen(db)
-                        db.query("PRAGMA journal_mode=WAL").close()
                         db.execSQL("PRAGMA synchronous=NORMAL;")
                         db.execSQL("PRAGMA cache_size=-32000;")
                         db.execSQL("PRAGMA temp_store=MEMORY;")

--- a/app/src/main/java/com/greenart7c3/citrine/database/AppDatabase.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/AppDatabase.kt
@@ -83,6 +83,25 @@ abstract class AppDatabase : RoomDatabase() {
                         db.execSQL("PRAGMA cache_size=-32000;")
                         db.execSQL("PRAGMA temp_store=MEMORY;")
                         db.query("PRAGMA mmap_size=268435456").close()
+                        // Increase WAL reader pool beyond the default of 2 so that
+                        // concurrent subscription queries don't serialize on connections.
+                        // FrameworkSQLiteDatabase wraps the real SQLiteDatabase in "delegate";
+                        // setMaxConnectionPoolSize is a hidden API so we reach it via reflection.
+                        try {
+                            val delegateField = db.javaClass.getDeclaredField("delegate")
+                            delegateField.isAccessible = true
+                            val sqliteDb = delegateField.get(db) as? SQLiteDatabase
+                            if (sqliteDb != null && sqliteDb.isWriteAheadLoggingEnabled) {
+                                val method = SQLiteDatabase::class.java.getDeclaredMethod(
+                                    "setMaxConnectionPoolSize",
+                                    Int::class.java,
+                                )
+                                method.isAccessible = true
+                                method.invoke(sqliteDb, numCores)
+                            }
+                        } catch (e: Exception) {
+                            Log.w(Citrine.TAG, "Could not expand WAL connection pool", e)
+                        }
                         _isDatabaseUpgrading.value = false
                     }
                 })

--- a/app/src/main/java/com/greenart7c3/citrine/database/AppDatabase.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/AppDatabase.kt
@@ -52,8 +52,9 @@ abstract class AppDatabase : RoomDatabase() {
                 _isDatabaseUpgrading.value = true
             }
 
-            val executor = Executors.newCachedThreadPool()
-            val transactionExecutor = Executors.newCachedThreadPool()
+            val numCores = Runtime.getRuntime().availableProcessors()
+            val executor = Executors.newFixedThreadPool(numCores * 2)
+            val transactionExecutor = Executors.newFixedThreadPool(2)
 
             val instance = Room.databaseBuilder(
                 context,
@@ -76,7 +77,11 @@ abstract class AppDatabase : RoomDatabase() {
                 .addCallback(object : Callback() {
                     override fun onOpen(db: SupportSQLiteDatabase) {
                         super.onOpen(db)
+                        db.execSQL("PRAGMA journal_mode=WAL;")
+                        db.execSQL("PRAGMA synchronous=NORMAL;")
                         db.execSQL("PRAGMA cache_size=-32000;")
+                        db.execSQL("PRAGMA temp_store=MEMORY;")
+                        db.execSQL("PRAGMA mmap_size=268435456;")
                         _isDatabaseUpgrading.value = false
                     }
                 })
@@ -120,7 +125,11 @@ abstract class HistoryDatabase : RoomDatabase() {
                 .addCallback(object : Callback() {
                     override fun onOpen(db: SupportSQLiteDatabase) {
                         super.onOpen(db)
+                        db.execSQL("PRAGMA journal_mode=WAL;")
+                        db.execSQL("PRAGMA synchronous=NORMAL;")
                         db.execSQL("PRAGMA cache_size=-32000;")
+                        db.execSQL("PRAGMA temp_store=MEMORY;")
+                        db.execSQL("PRAGMA mmap_size=268435456;")
                     }
                 })
                 .build()

--- a/app/src/main/java/com/greenart7c3/citrine/database/AppDatabase.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/AppDatabase.kt
@@ -77,11 +77,12 @@ abstract class AppDatabase : RoomDatabase() {
                 .addCallback(object : Callback() {
                     override fun onOpen(db: SupportSQLiteDatabase) {
                         super.onOpen(db)
-                        db.execSQL("PRAGMA journal_mode=WAL;")
+                        // journal_mode and mmap_size return a result row, so use query() not execSQL()
+                        db.query("PRAGMA journal_mode=WAL").close()
                         db.execSQL("PRAGMA synchronous=NORMAL;")
                         db.execSQL("PRAGMA cache_size=-32000;")
                         db.execSQL("PRAGMA temp_store=MEMORY;")
-                        db.execSQL("PRAGMA mmap_size=268435456;")
+                        db.query("PRAGMA mmap_size=268435456").close()
                         _isDatabaseUpgrading.value = false
                     }
                 })
@@ -125,11 +126,11 @@ abstract class HistoryDatabase : RoomDatabase() {
                 .addCallback(object : Callback() {
                     override fun onOpen(db: SupportSQLiteDatabase) {
                         super.onOpen(db)
-                        db.execSQL("PRAGMA journal_mode=WAL;")
+                        db.query("PRAGMA journal_mode=WAL").close()
                         db.execSQL("PRAGMA synchronous=NORMAL;")
                         db.execSQL("PRAGMA cache_size=-32000;")
                         db.execSQL("PRAGMA temp_store=MEMORY;")
-                        db.execSQL("PRAGMA mmap_size=268435456;")
+                        db.query("PRAGMA mmap_size=268435456").close()
                     }
                 })
                 .build()

--- a/app/src/main/java/com/greenart7c3/citrine/database/EventDao.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/EventDao.kt
@@ -25,6 +25,14 @@ interface EventDao {
     @RawQuery
     fun getEvents(query: SupportSQLiteQuery): List<EventWithTags>
 
+    /** Returns only EventEntity rows — no @Relation tag loading, so no N+1 queries. */
+    @RawQuery
+    fun getEventsOnly(query: SupportSQLiteQuery): List<EventEntity>
+
+    /** Batch-loads all tags for the given event IDs in a single query. */
+    @Query("SELECT * FROM TagEntity WHERE pkEvent IN (:eventIds)")
+    fun getTagsForEvents(eventIds: List<String>): List<TagEntity>
+
     @RawQuery
     fun count(query: SupportSQLiteQuery): Int
 
@@ -178,25 +186,20 @@ interface EventDao {
     @Transaction
     suspend fun deleteAllTags()
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
     @Transaction
     suspend fun insertEventWithTags(
         dbEvent: EventWithTags,
         connection: Connection?,
         sendEventToSubscriptions: Boolean = true,
-    ) {
-        deletetags(dbEvent.event.id)
-        insertEvent(dbEvent.event)?.let {
-            dbEvent.tags.forEach {
-                it.pkEvent = dbEvent.event.id
-            }
-
-            insertTags(dbEvent.tags)
-
-            if (sendEventToSubscriptions && connection != null) {
-                EventSubscription.executeAll(dbEvent, connection)
-            }
+    ): Boolean {
+        val rowId = insertEvent(dbEvent.event) ?: return false
+        // Only reached for genuinely new events — safe to insert tags now
+        dbEvent.tags.forEach { it.pkEvent = dbEvent.event.id }
+        insertTags(dbEvent.tags)
+        if (sendEventToSubscriptions && connection != null) {
+            EventSubscription.executeAll(dbEvent, connection)
         }
+        return rowId > 0
     }
 
     @Transaction
@@ -239,12 +242,8 @@ interface EventDao {
 
     @Query(
         """
-        SELECT EventEntity.id
-          FROM EventEntity EventEntity
-         INNER JOIN TagEntity TagEntity ON EventEntity.id = TagEntity.pkEvent
-         WHERE TagEntity.col0Name = 'e'
-           AND TagEntity.col1Value = :eTagValue
-           AND EventEntity.kind = 5
+        SELECT pkEvent FROM TagEntity
+         WHERE kind = 5 AND col0Name = 'e' AND col1Value = :eTagValue
         """,
     )
     @Transaction

--- a/app/src/main/java/com/greenart7c3/citrine/database/EventDao.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/EventDao.kt
@@ -33,6 +33,10 @@ interface EventDao {
     @Query("SELECT * FROM TagEntity WHERE pkEvent IN (:eventIds)")
     fun getTagsForEvents(eventIds: List<String>): List<TagEntity>
 
+    /** Batch-loads the pre-serialized JSON cache for the given event IDs. */
+    @Query("SELECT id, json FROM EventEntity WHERE id IN (:ids)")
+    fun getEventJsonForIds(ids: List<String>): List<EventIdAndJson>
+
     @RawQuery
     fun count(query: SupportSQLiteQuery): Int
 
@@ -323,6 +327,12 @@ interface EventDao {
         offset: Int,
     ): List<EventWithTags>
 }
+
+/** Lightweight projection used by [EventDao.getEventJsonForIds] to load cached JSON in bulk. */
+data class EventIdAndJson(
+    val id: String,
+    val json: String,
+)
 
 data class EventKey(
     val createdAt: Long,

--- a/app/src/main/java/com/greenart7c3/citrine/database/EventDao.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/EventDao.kt
@@ -33,10 +33,6 @@ interface EventDao {
     @Query("SELECT * FROM TagEntity WHERE pkEvent IN (:eventIds)")
     fun getTagsForEvents(eventIds: List<String>): List<TagEntity>
 
-    /** Batch-loads the pre-serialized JSON cache for the given event IDs. */
-    @Query("SELECT id, json FROM EventEntity WHERE id IN (:ids)")
-    fun getEventJsonForIds(ids: List<String>): List<EventIdAndJson>
-
     @RawQuery
     fun count(query: SupportSQLiteQuery): Int
 
@@ -327,12 +323,6 @@ interface EventDao {
         offset: Int,
     ): List<EventWithTags>
 }
-
-/** Lightweight projection used by [EventDao.getEventJsonForIds] to load cached JSON in bulk. */
-data class EventIdAndJson(
-    val id: String,
-    val json: String,
-)
 
 data class EventKey(
     val createdAt: Long,

--- a/app/src/main/java/com/greenart7c3/citrine/database/EventEntity.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/EventEntity.kt
@@ -11,6 +11,7 @@ import androidx.room.TypeConverter
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
 import com.vitorpamplona.quartz.utils.EventFactory
 
 @Entity(
@@ -45,6 +46,11 @@ data class EventEntity(
     val kind: Int,
     val content: String,
     val sig: String,
+    /** Pre-serialized event JSON object (the inner `{…}` without the outer `["EVENT",…]` wrapper).
+     *  Empty string for events inserted before migration 12; those fall back to ByteWriter encoding. */
+    val json: String = "",
+    /** NIP-40 expiration timestamp in seconds, or null if the event has no expiration tag. */
+    val expiresAt: Long? = null,
 )
 
 data class EventWithTags(
@@ -132,6 +138,32 @@ fun TagEntity.toTags(): Array<String> = listOfNotNull(
 ).plus(col4Plus).toTypedArray()
 
 fun Event.toEventWithTags(): EventWithTags {
+    // Serialize the event JSON once at insert time so subscribe() can avoid per-query encoding.
+    val json = try {
+        val factory = JacksonMapper.mapper.nodeFactory
+        val node = factory.objectNode().apply {
+            put("id", id)
+            put("pubkey", pubKey)
+            put("created_at", createdAt)
+            put("kind", kind)
+            replace(
+                "tags",
+                factory.arrayNode(tags.size).apply {
+                    tags.forEach { tag ->
+                        add(factory.arrayNode(tag.size).apply { tag.forEach { add(it) } })
+                    }
+                },
+            )
+            put("content", content)
+            put("sig", sig)
+        }
+        JacksonMapper.mapper.writeValueAsString(node)
+    } catch (_: Exception) {
+        ""
+    }
+    // Cache the NIP-40 expiration so subscribe() avoids loading tags just for expiry checks.
+    val expiresAt = tags.firstOrNull { it.getOrNull(0) == "expiration" }?.getOrNull(1)?.toLongOrNull()
+
     val dbEvent = EventEntity(
         id = id,
         pubkey = pubKey,
@@ -139,6 +171,8 @@ fun Event.toEventWithTags(): EventWithTags {
         kind = kind,
         content = content,
         sig = sig,
+        json = json,
+        expiresAt = expiresAt,
     )
 
     val dbTags = tags.mapIndexed { index, tag ->

--- a/app/src/main/java/com/greenart7c3/citrine/database/EventEntity.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/EventEntity.kt
@@ -137,9 +137,19 @@ fun TagEntity.toTags(): Array<String> = listOfNotNull(
     col3Amount,
 ).plus(col4Plus).toTypedArray()
 
-fun Event.toEventWithTags(): EventWithTags {
-    // Serialize the event JSON once at insert time so subscribe() can avoid per-query encoding.
-    val json = try {
+/**
+ * Converts this [Event] to the Room entity pair used for storage.
+ *
+ * @param rawJson  The original JSON string received from the client, if available.
+ *                 When provided it is stored directly in [EventEntity.json] without a
+ *                 round-trip through Jackson, saving the cost of re-serializing fields
+ *                 that were already serialised by the sender.  Callers that do not have
+ *                 the raw string (e.g. import paths) can omit this parameter and the
+ *                 field will be constructed from the [Event] fields as before.
+ */
+fun Event.toEventWithTags(rawJson: String? = null): EventWithTags {
+    // Use the raw request JSON when available; otherwise re-serialize from the Event fields.
+    val json = rawJson ?: try {
         val factory = JacksonMapper.mapper.nodeFactory
         val node = factory.objectNode().apply {
             put("id", id)

--- a/app/src/main/java/com/greenart7c3/citrine/server/Connection.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Connection.kt
@@ -77,4 +77,22 @@ class Connection(
             Log.d(Citrine.TAG, "Error sending data to client $data", e)
         }
     }
+
+    /** Sends a pre-built [Frame] directly, avoiding a redundant String→ByteArray encoding step. */
+    fun trySend(frame: Frame) {
+        try {
+            session.outgoing.trySend(frame).onClosed {
+                val connection = EventSubscription.getConnection(session)
+                connection?.let {
+                    Log.d(Citrine.TAG, "Session is closed for connection ${connection.name} ${connection.remoteAddress()}")
+                    Citrine.instance.applicationScope.launch {
+                        CustomWebSocketService.server?.removeConnection(connection)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Log.d(Citrine.TAG, "Error sending frame to client", e)
+        }
+    }
 }

--- a/app/src/main/java/com/greenart7c3/citrine/server/Connection.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Connection.kt
@@ -95,4 +95,21 @@ class Connection(
             Log.d(Citrine.TAG, "Error sending frame to client", e)
         }
     }
+
+    /**
+     * Suspending send that waits for the outgoing channel to accept the frame rather than
+     * dropping it silently. Use this for event frames in subscribe() so that no events are
+     * lost when the outgoing buffer is temporarily full.
+     *
+     * Returns true if the frame was sent, false if the channel was already closed.
+     */
+    suspend fun send(frame: Frame): Boolean = try {
+        session.outgoing.send(frame)
+        true
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Log.d(Citrine.TAG, "Error sending frame to client (connection closed)", e)
+        false
+    }
 }

--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -429,13 +429,6 @@ class CustomWebSocketServer(
                     return VerificationResult.NewestEventAlreadyInDatabase
                 }
             }
-            else -> {
-                val eventEntity = appDatabase.eventDao().getById(event.id)
-                if (eventEntity != null && !event.isEphemeral()) {
-                    Log.d(Citrine.TAG, "Event already in database ${event.id}")
-                    return VerificationResult.AlreadyInDatabase
-                }
-            }
         }
         if (!event.verify()) {
             Log.d(Citrine.TAG, "event ${event.id} does not have a valid id or signature")
@@ -492,24 +485,29 @@ class CustomWebSocketServer(
                 connection?.trySend(CommandResult.invalid(event, "newest event already in database").toJson())
             }
             VerificationResult.Valid -> {
-                when {
+                val saved = when {
                     event.shouldDelete() -> {
                         deleteEvent(event, connection)
+                        true
                     }
                     event.isParameterizedReplaceable() -> {
                         handleParameterizedReplaceable(event, connection)
+                        true
                     }
                     event.shouldOverwrite() -> {
                         override(event, connection)
+                        true
                     }
-                    else -> {
-                        save(event, connection)
-                    }
+                    else -> save(event, connection)
                 }
 
                 // if the event is ephemeral the response will be sent after the event is sent to subscriptions
                 if (!event.isEphemeral()) {
-                    connection?.trySend(CommandResult.ok(event).toJson())
+                    if (saved) {
+                        connection?.trySend(CommandResult.ok(event).toJson())
+                    } else {
+                        connection?.trySend(CommandResult.duplicated(event).toJson())
+                    }
                 }
             }
         }
@@ -566,16 +564,17 @@ class CustomWebSocketServer(
         }
     }
 
-    private suspend fun save(event: Event, connection: Connection?) {
-        appDatabase.eventDao().insertEventWithTags(event.toEventWithTags(), connection = connection)
+    private suspend fun save(event: Event, connection: Connection?): Boolean {
+        val inserted = appDatabase.eventDao().insertEventWithTags(event.toEventWithTags(), connection = connection)
 
         // Check if offline and broadcast with WorkManager
-        if (isOffline()) {
+        if (inserted && isOffline()) {
             val dbEvent = appDatabase.eventDao().getById(event.id)
             if (dbEvent != null) {
                 broadcastWithWorkManager(dbEvent)
             }
         }
+        return inserted
     }
 
     private suspend fun deleteEvent(event: Event, connection: Connection?) {

--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -810,7 +810,7 @@ class CustomWebSocketServer(
                         /**
                          * Prevent compressing small outgoing frames.
                          */
-                        compressIfBiggerThan(bytes = 0)
+                        compressIfBiggerThan(bytes = 8192)
                     }
                 }
             }

--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -274,8 +274,9 @@ class CustomWebSocketServer(
                 }
 
                 "EVENT" -> {
-                    val event = Event.fromJson(msgArray.get(1).toString())
-                    processEvent(event, connection)
+                    val rawJson = msgArray.get(1).toString()
+                    val event = Event.fromJson(rawJson)
+                    processEvent(event, connection, rawJson)
                 }
 
                 "CLOSE" -> {
@@ -437,7 +438,7 @@ class CustomWebSocketServer(
         return VerificationResult.Valid
     }
 
-    suspend fun innerProcessEvent(event: Event, connection: Connection?, shouldVerify: Boolean = true): VerificationResult {
+    suspend fun innerProcessEvent(event: Event, connection: Connection?, shouldVerify: Boolean = true, rawJson: String? = null): VerificationResult {
         val result = verifyEvent(event, connection, shouldVerify)
         when (result) {
             VerificationResult.AuthRequiredForProtectedEvent -> {
@@ -487,18 +488,18 @@ class CustomWebSocketServer(
             VerificationResult.Valid -> {
                 val saved = when {
                     event.shouldDelete() -> {
-                        deleteEvent(event, connection)
+                        deleteEvent(event, connection, rawJson)
                         true
                     }
                     event.isParameterizedReplaceable() -> {
-                        handleParameterizedReplaceable(event, connection)
+                        handleParameterizedReplaceable(event, connection, rawJson)
                         true
                     }
                     event.shouldOverwrite() -> {
-                        override(event, connection)
+                        override(event, connection, rawJson)
                         true
                     }
-                    else -> save(event, connection)
+                    else -> save(event, connection, rawJson)
                 }
 
                 // if the event is ephemeral the response will be sent after the event is sent to subscriptions
@@ -514,23 +515,23 @@ class CustomWebSocketServer(
         return result
     }
 
-    private suspend fun processEvent(event: Event, connection: Connection?) {
-        innerProcessEvent(event, connection)
+    private suspend fun processEvent(event: Event, connection: Connection?, rawJson: String? = null) {
+        innerProcessEvent(event, connection, rawJson = rawJson)
     }
 
-    private suspend fun handleParameterizedReplaceable(event: Event, connection: Connection?) {
-        save(event, connection)
+    private suspend fun handleParameterizedReplaceable(event: Event, connection: Connection?, rawJson: String? = null) {
+        save(event, connection, rawJson)
         val ids = appDatabase.eventDao().getOldestReplaceable(event.kind, event.pubKey, event.tags.firstOrNull { it.size > 1 && it[0] == "d" }?.get(1) ?: "")
         appDatabase.eventDao().delete(ids, event.pubKey)
-        HistoryDatabase.getDatabase(Citrine.instance).eventDao().insertEventWithTags(event.toEventWithTags(), connection = connection, sendEventToSubscriptions = false)
+        HistoryDatabase.getDatabase(Citrine.instance).eventDao().insertEventWithTags(event.toEventWithTags(rawJson), connection = connection, sendEventToSubscriptions = false)
     }
 
-    private suspend fun override(event: Event, connection: Connection?) {
-        save(event, connection)
+    private suspend fun override(event: Event, connection: Connection?, rawJson: String? = null) {
+        save(event, connection, rawJson)
         val ids = appDatabase.eventDao().getByKind(event.kind, event.pubKey).drop(1)
         if (ids.isEmpty()) return
         appDatabase.eventDao().delete(ids, event.pubKey)
-        HistoryDatabase.getDatabase(Citrine.instance).eventDao().insertEventWithTags(event.toEventWithTags(), connection = connection, sendEventToSubscriptions = false)
+        HistoryDatabase.getDatabase(Citrine.instance).eventDao().insertEventWithTags(event.toEventWithTags(rawJson), connection = connection, sendEventToSubscriptions = false)
     }
 
     private fun isOffline(): Boolean {
@@ -564,8 +565,8 @@ class CustomWebSocketServer(
         }
     }
 
-    private suspend fun save(event: Event, connection: Connection?): Boolean {
-        val inserted = appDatabase.eventDao().insertEventWithTags(event.toEventWithTags(), connection = connection)
+    private suspend fun save(event: Event, connection: Connection?, rawJson: String? = null): Boolean {
+        val inserted = appDatabase.eventDao().insertEventWithTags(event.toEventWithTags(rawJson), connection = connection)
 
         // Check if offline and broadcast with WorkManager
         if (inserted && isOffline()) {
@@ -577,8 +578,8 @@ class CustomWebSocketServer(
         return inserted
     }
 
-    private suspend fun deleteEvent(event: Event, connection: Connection?) {
-        save(event, connection)
+    private suspend fun deleteEvent(event: Event, connection: Connection?, rawJson: String? = null) {
+        save(event, connection, rawJson)
         appDatabase.eventDao().delete(event.taggedEvents().map { it.eventId }, event.pubKey)
         val taggedAddresses = event.taggedAddresses()
         if (taggedAddresses.isEmpty()) return

--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -1037,7 +1037,7 @@ class CustomWebSocketServer(
                     val thisConnection = Connection(this)
                     connections.emit(connections.value + thisConnection)
 
-                    val maxParallelMessages = 8
+                    val maxParallelMessages = 32
 
                     val job = launch {
                         thisConnection.sharedFlow

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventFilter.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventFilter.kt
@@ -36,7 +36,7 @@ data class EventFilter(
             return false
         }
 
-        if (tags.isNotEmpty() && tags.none { testTag(it, event) }) {
+        if (tags.isNotEmpty() && !tags.all { testTag(it, event) }) {
             return false
         }
 

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -27,6 +27,16 @@ object EventRepository {
         permits = Runtime.getRuntime().availableProcessors().coerceIn(2, 4),
     )
 
+    // Separate permit pool for the send phase.  Without this, all 100 subscription coroutines
+    // would enter their send loops simultaneously after releasing their query permits, saturating
+    // the IO thread pool and triggering heavy GC pressure (100 concurrent ByteArray allocation
+    // storms ≈ 20 MB live data) that pauses all threads including the event publishing path.
+    // Using 2× queryPermits lets sends and DB queries fully overlap while keeping the concurrent
+    // allocation footprint small enough to avoid triggering a major GC.
+    private val sendPermits = Semaphore(
+        permits = Runtime.getRuntime().availableProcessors().coerceIn(2, 4) * 2,
+    )
+
     fun createQuery(
         filter: EventFilter,
         count: Boolean,
@@ -232,35 +242,40 @@ object EventRepository {
             // so other subscriptions can start their DB queries while we are waiting to send.
         } ?: return
 
-        // Send loop runs OUTSIDE the semaphore permit.  Releasing the permit here lets other
-        // subscription coroutines begin their DB work while we are writing to the network.
+        // Send loop runs OUTSIDE the query permit but inside a separate send permit.
+        // - Query permit released first: other subscriptions can start their DB work now.
+        // - Send permit limits concurrency: prevents all 100 subscription coroutines from
+        //   entering their send loops simultaneously, which would saturate the IO thread pool
+        //   and trigger heavy GC pressure from concurrent ByteArray allocation.
         val nowSeconds = System.currentTimeMillis() / 1000
         val subIdBytes = subscription.id.encodeToByteArray()
 
         var buildNs = 0L
         var sendNs = 0L
-        for (eventEntity in data.eventEntities) {
-            // NIP-40 expiration: prefer cached expiresAt, fall back to tag scan for legacy events.
-            val expiry = eventEntity.expiresAt
-                ?: data.tagsByEvent[eventEntity.id]?.firstOrNull { it.col0Name == "expiration" }
-                    ?.col1Value?.toLongOrNull()
-            if (expiry != null && expiry < nowSeconds) continue
+        sendPermits.withPermit {
+            for (eventEntity in data.eventEntities) {
+                // NIP-40 expiration: prefer cached expiresAt, fall back to tag scan for legacy events.
+                val expiry = eventEntity.expiresAt
+                    ?: data.tagsByEvent[eventEntity.id]?.firstOrNull { it.col0Name == "expiration" }
+                        ?.col1Value?.toLongOrNull()
+                if (expiry != null && expiry < nowSeconds) continue
 
-            val tb = System.nanoTime()
-            val eventJson = data.jsonById[eventEntity.id]?.json ?: ""
-            val bytes = if (eventJson.isNotEmpty()) {
-                // Fast path: one native encodeToByteArray() + three arraycopy calls.
-                buildCachedEventMessageBytes(subIdBytes, eventJson)
-            } else {
-                // Legacy path: ByteWriter char-by-char encoder for pre-migration events.
-                buildEventMessageBytes(subscription.id, eventEntity, data.tagsByEvent[eventEntity.id] ?: emptyList())
+                val tb = System.nanoTime()
+                val eventJson = data.jsonById[eventEntity.id]?.json ?: ""
+                val bytes = if (eventJson.isNotEmpty()) {
+                    // Fast path: one native encodeToByteArray() + three arraycopy calls.
+                    buildCachedEventMessageBytes(subIdBytes, eventJson)
+                } else {
+                    // Legacy path: ByteWriter char-by-char encoder for pre-migration events.
+                    buildEventMessageBytes(subscription.id, eventEntity, data.tagsByEvent[eventEntity.id] ?: emptyList())
+                }
+                val ts = System.nanoTime()
+                // Suspending send: waits for channel capacity instead of dropping frames silently.
+                if (!subscription.connection.send(Frame.Text(true, bytes))) break
+                val te = System.nanoTime()
+                buildNs += ts - tb
+                sendNs += te - ts
             }
-            val ts = System.nanoTime()
-            // Suspending send: waits for channel capacity instead of dropping frames silently.
-            if (!subscription.connection.send(Frame.Text(true, bytes))) break
-            val te = System.nanoTime()
-            buildNs += ts - tb
-            sendNs += te - ts
         }
         val t4 = System.nanoTime()
         Log.d(

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -1,7 +1,9 @@
 package com.greenart7c3.citrine.server
 
+import android.util.Log
 import androidx.sqlite.db.SimpleSQLiteQuery
 import com.fasterxml.jackson.databind.JsonNode
+import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.EventEntity
 import com.greenart7c3.citrine.database.EventWithTags
@@ -158,7 +160,9 @@ object EventRepository {
     ) {
         // Acquire a permit before touching the DB so that at most queryPermits.availablePermits
         // coroutines block on the connection pool at once, eliminating thundering-herd contention.
+        val t0 = System.nanoTime()
         queryPermits.withPermit {
+            val t1 = System.nanoTime()
             if (subscription.count) {
                 val count = countQuery(subscription.appDatabase, filter)
                 subscription.connection.trySend(
@@ -176,6 +180,7 @@ object EventRepository {
             val (sql, params) = createQuery(filter, false)
             val rawSql = SimpleSQLiteQuery(sql, params.toTypedArray())
             val eventEntities = subscription.appDatabase.eventDao().getEventsOnly(rawSql)
+            val t2 = System.nanoTime()
             if (eventEntities.isEmpty()) return@withPermit
 
             // Batch-load all tags in one query instead of Room's @Relation N+1 pattern.
@@ -188,6 +193,7 @@ object EventRepository {
                 .flatten()
                 .groupBy { it.pkEvent }
 
+            val t3 = System.nanoTime()
             val nowSeconds = System.currentTimeMillis() / 1000
 
             eventEntities.forEach { eventEntity ->
@@ -200,6 +206,15 @@ object EventRepository {
                 // Build the EVENT message as a raw JSON string without Jackson intermediaries
                 subscription.connection.trySend(buildEventMessage(subscription.id, eventEntity, tags))
             }
+            val t4 = System.nanoTime()
+            Log.d(
+                Citrine.TAG,
+                "subscribe phases: semWait=${(t1 - t0) / 1_000_000}ms " +
+                    "query1=${(t2 - t1) / 1_000_000}ms " +
+                    "tags=${(t3 - t2) / 1_000_000}ms " +
+                    "send=${(t4 - t3) / 1_000_000}ms " +
+                    "events=${eventEntities.size}",
+            )
         }
     }
 }

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -56,12 +56,11 @@ object EventRepository {
             params.addAll(filter.kinds)
         }
 
-        // --- Single JOIN (just for connecting EventEntity with TagEntity if needed) ---
-        if (filter.tags.isNotEmpty()) {
-            joinClause.append(" INNER JOIN TagEntity t ON t.pkEvent = EventEntity.id")
-        }
-
         // --- Add each tag as an AND EXISTS in WHERE ---
+        // Note: there is intentionally no INNER JOIN on TagEntity here.
+        // A JOIN would expand each event into N rows (one per tag) and require DISTINCT to
+        // deduplicate — multiplying work by avg_tags_per_event for no benefit.
+        // EXISTS subqueries handle the filtering directly on the EventEntity rows.
         filter.tags.forEach { tag ->
             val safeTagKey = tag.key.takeIf { it.matches(Regex("^[a-zA-Z0-9]+$")) }
                 ?: throw IllegalArgumentException("Invalid tag key: ${tag.key}")
@@ -91,7 +90,6 @@ object EventRepository {
         // --- Build SQL ---
         val joinSql = if (joinClause.isNotEmpty()) joinClause.toString() else ""
         val predicatesSql = if (whereClause.isNotEmpty()) whereClause.joinToString(" AND ", prefix = "WHERE ") else ""
-        val distinctSql = if (filter.tags.isNotEmpty()) "DISTINCT " else ""
 
         val orderBy = if (filter.searchKeywords.isNotEmpty()) {
             "EventEntity.rowid DESC"
@@ -101,14 +99,14 @@ object EventRepository {
 
         var query = if (count) {
             """
-        SELECT COUNT(DISTINCT EventEntity.id)
+        SELECT COUNT(EventEntity.id)
           FROM EventEntity EventEntity
           $joinSql
           $predicatesSql
             """.trimIndent()
         } else {
             """
-        SELECT $distinctSql EventEntity.*
+        SELECT EventEntity.*
           FROM EventEntity EventEntity
           $joinSql
           $predicatesSql

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -27,16 +27,6 @@ object EventRepository {
         permits = Runtime.getRuntime().availableProcessors().coerceIn(2, 4),
     )
 
-    // Separate permit pool for the send phase.  Without this, all 100 subscription coroutines
-    // would enter their send loops simultaneously after releasing their query permits, saturating
-    // the IO thread pool and triggering heavy GC pressure (100 concurrent ByteArray allocation
-    // storms ≈ 20 MB live data) that pauses all threads including the event publishing path.
-    // Using 2× queryPermits lets sends and DB queries fully overlap while keeping the concurrent
-    // allocation footprint small enough to avoid triggering a major GC.
-    private val sendPermits = Semaphore(
-        permits = Runtime.getRuntime().availableProcessors().coerceIn(2, 4) * 2,
-    )
-
     fun createQuery(
         filter: EventFilter,
         count: Boolean,
@@ -242,40 +232,31 @@ object EventRepository {
             // so other subscriptions can start their DB queries while we are waiting to send.
         } ?: return
 
-        // Send loop runs OUTSIDE the query permit but inside a separate send permit.
-        // - Query permit released first: other subscriptions can start their DB work now.
-        // - Send permit limits concurrency: prevents all 100 subscription coroutines from
-        //   entering their send loops simultaneously, which would saturate the IO thread pool
-        //   and trigger heavy GC pressure from concurrent ByteArray allocation.
+        // Send loop runs OUTSIDE the query permit so other subscriptions can start their DB
+        // queries while we are sending.  trySend() on Ktor's UNLIMITED outgoing channel is
+        // effectively free (~1 μs/frame, no coroutine yield) and never drops frames — it only
+        // fails when the session is already closed, which is handled by onClosed.  A second
+        // "send" semaphore is intentionally absent: each send loop completes in <1 ms total
+        // (100 events × ~1 μs), so 100 concurrent loops impose negligible GC and CPU pressure.
         val nowSeconds = System.currentTimeMillis() / 1000
         val subIdBytes = subscription.id.encodeToByteArray()
 
-        var buildNs = 0L
-        var sendNs = 0L
-        sendPermits.withPermit {
-            for (eventEntity in data.eventEntities) {
-                // NIP-40 expiration: prefer cached expiresAt, fall back to tag scan for legacy events.
-                val expiry = eventEntity.expiresAt
-                    ?: data.tagsByEvent[eventEntity.id]?.firstOrNull { it.col0Name == "expiration" }
-                        ?.col1Value?.toLongOrNull()
-                if (expiry != null && expiry < nowSeconds) continue
+        for (eventEntity in data.eventEntities) {
+            // NIP-40 expiration: prefer cached expiresAt, fall back to tag scan for legacy events.
+            val expiry = eventEntity.expiresAt
+                ?: data.tagsByEvent[eventEntity.id]?.firstOrNull { it.col0Name == "expiration" }
+                    ?.col1Value?.toLongOrNull()
+            if (expiry != null && expiry < nowSeconds) continue
 
-                val tb = System.nanoTime()
-                val eventJson = data.jsonById[eventEntity.id]?.json ?: ""
-                val bytes = if (eventJson.isNotEmpty()) {
-                    // Fast path: one native encodeToByteArray() + three arraycopy calls.
-                    buildCachedEventMessageBytes(subIdBytes, eventJson)
-                } else {
-                    // Legacy path: ByteWriter char-by-char encoder for pre-migration events.
-                    buildEventMessageBytes(subscription.id, eventEntity, data.tagsByEvent[eventEntity.id] ?: emptyList())
-                }
-                val ts = System.nanoTime()
-                // Suspending send: waits for channel capacity instead of dropping frames silently.
-                if (!subscription.connection.send(Frame.Text(true, bytes))) break
-                val te = System.nanoTime()
-                buildNs += ts - tb
-                sendNs += te - ts
+            val eventJson = data.jsonById[eventEntity.id]?.json ?: ""
+            val bytes = if (eventJson.isNotEmpty()) {
+                // Fast path: one native encodeToByteArray() + three arraycopy calls.
+                buildCachedEventMessageBytes(subIdBytes, eventJson)
+            } else {
+                // Legacy path: ByteWriter char-by-char encoder for pre-migration events.
+                buildEventMessageBytes(subscription.id, eventEntity, data.tagsByEvent[eventEntity.id] ?: emptyList())
             }
+            subscription.connection.trySend(Frame.Text(true, bytes))
         }
         val t4 = System.nanoTime()
         Log.d(
@@ -284,7 +265,6 @@ object EventRepository {
                 "query1=${(data.t2 - data.t1) / 1_000_000}ms " +
                 "json=${(data.t3 - data.t2) / 1_000_000}ms " +
                 "send=${(t4 - data.t3) / 1_000_000}ms " +
-                "build=${buildNs / 1_000_000}ms trySend=${sendNs / 1_000_000}ms " +
                 "events=${data.eventEntities.size} legacy=${data.legacyCount}",
         )
     }

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -207,12 +207,12 @@ object EventRepository {
                 val expiry = tags.firstOrNull { it.col0Name == "expiration" }?.col1Value?.toLongOrNull()
                 if (expiry != null && expiry < nowSeconds) return@forEach
 
-                // Build the EVENT message as a raw JSON string without Jackson intermediaries
+                // Build the EVENT message bytes directly — avoids String→ByteArray re-encoding.
                 val tb = System.nanoTime()
-                val msg = buildEventMessage(subscription.id, eventEntity, tags)
+                val bytes = buildEventMessageBytes(subscription.id, eventEntity, tags)
                 val ts = System.nanoTime()
-                // Pre-encode String→ByteArray once here; Frame.Text(String) would do this anyway.
-                val frame = Frame.Text(msg)
+                // Frame.Text(true, byteArray) uses the bytes as-is with no further encoding.
+                val frame = Frame.Text(true, bytes)
                 val tf = System.nanoTime()
                 subscription.connection.trySend(frame)
                 val te = System.nanoTime()
@@ -234,84 +234,171 @@ object EventRepository {
     }
 }
 
-/** Builds ["EVENT","<subId>",{event}] without Jackson intermediate objects. */
-private fun buildEventMessage(subId: String, entity: EventEntity, tags: List<TagEntity>): String = buildString(capacity = 1024) {
-    append("[\"EVENT\",")
-    appendJsonEncoded(subId)
-    append(",{\"id\":\"")
-    append(entity.id)
-    append("\",\"pubkey\":\"")
-    append(entity.pubkey)
-    append("\",\"created_at\":")
-    append(entity.createdAt)
-    append(",\"kind\":")
-    append(entity.kind)
-    append(",\"tags\":[")
-    tags.forEachIndexed { i, tag ->
-        if (i > 0) append(',')
-        append('[')
-        appendTagParts(tag)
-        append(']')
+/**
+ * Builds ["EVENT","<subId>",{event}] directly as a UTF-8 [ByteArray].
+ *
+ * Writing bytes once (instead of writing chars to a StringBuilder then re-encoding to bytes
+ * inside Frame.Text(String)) eliminates a full second O(N) pass over every character.
+ */
+private fun buildEventMessageBytes(subId: String, entity: EventEntity, tags: List<TagEntity>): ByteArray {
+    val estSize = 120 + entity.id.length + entity.pubkey.length + entity.sig.length +
+        entity.content.length + tags.sumOf { 6 + (it.col0Name?.length ?: 0) + (it.col1Value?.length ?: 0) }
+    val w = ByteWriter(estSize)
+    w.writeAscii("[\"EVENT\",")
+    w.writeJsonEncoded(subId)
+    w.writeAscii(",{\"id\":\"")
+    w.writeAscii(entity.id)
+    w.writeAscii("\",\"pubkey\":\"")
+    w.writeAscii(entity.pubkey)
+    w.writeAscii("\",\"created_at\":")
+    w.writeAscii(entity.createdAt.toString())
+    w.writeAscii(",\"kind\":")
+    w.writeAscii(entity.kind.toString())
+    w.writeAscii(",\"tags\":[")
+    tags.forEachIndexed { idx, tag ->
+        if (idx > 0) w.writeByte(','.code)
+        w.writeByte('['.code)
+        var first = true
+        fun part(s: String?) {
+            if (s == null) return
+            if (!first) w.writeByte(','.code)
+            first = false
+            w.writeJsonEncoded(s)
+        }
+        part(tag.col0Name)
+        part(tag.col1Value)
+        part(tag.col2Differentiator)
+        part(tag.col3Amount)
+        tag.col4Plus.forEach { part(it) }
+        w.writeByte(']'.code)
     }
-    append("],\"content\":")
-    appendJsonEncoded(entity.content)
-    append(",\"sig\":\"")
-    append(entity.sig)
-    append("\"}]")
-}
-
-/** Appends the non-null tag parts as a comma-separated JSON string list. */
-private fun StringBuilder.appendTagParts(tag: TagEntity) {
-    var first = true
-    fun part(s: String?) {
-        if (s == null) return
-        if (!first) append(',')
-        first = false
-        appendJsonEncoded(s)
-    }
-    part(tag.col0Name)
-    part(tag.col1Value)
-    part(tag.col2Differentiator)
-    part(tag.col3Amount)
-    tag.col4Plus.forEach { part(it) }
+    w.writeAscii("],\"content\":")
+    w.writeJsonEncoded(entity.content)
+    w.writeAscii(",\"sig\":\"")
+    w.writeAscii(entity.sig)
+    w.writeAscii("\"}]")
+    return w.toByteArray()
 }
 
 /**
- * Appends [s] as a JSON-encoded string (surrounding quotes + proper escaping).
+ * Minimal resizable byte buffer for building UTF-8 JSON without a String intermediary.
  *
- * Uses a bulk-copy strategy: scan for characters that need escaping, and flush
- * the unescaped runs between them with a single [StringBuilder.append] call that
- * resolves to [System.arraycopy] internally — orders of magnitude faster than the
- * previous char-by-char append loop for typical content with few or no special chars.
+ * Replacing StringBuilder+Frame.Text(String) with this writer eliminates one full O(N)
+ * encoding pass: chars are encoded to bytes exactly once, and Frame.Text(true, byteArray)
+ * uses the result directly with no further conversion.
  */
-private fun StringBuilder.appendJsonEncoded(s: String) {
-    append('"')
-    var start = 0
-    val len = s.length
-    var i = 0
-    while (i < len) {
-        val ch = s[i]
-        // Fast path: printable ASCII that isn't " or \ needs no escaping — keep scanning.
-        if (ch.code >= 0x20 && ch != '"' && ch != '\\') {
-            i++
-            continue
-        }
-        // Flush the unescaped run [start, i) as a single bulk copy (System.arraycopy).
-        if (i > start) append(s, start, i)
-        when (ch) {
-            '"' -> append("\\\"")
-            '\\' -> append("\\\\")
-            '\n' -> append("\\n")
-            '\r' -> append("\\r")
-            '\t' -> append("\\t")
-            else -> append("\\u").append(ch.code.toString(16).padStart(4, '0'))
-        }
-        start = i + 1
-        i++
+private class ByteWriter(initialCapacity: Int) {
+    private var buf = ByteArray(initialCapacity)
+    private var pos = 0
+
+    private fun ensure(n: Int) {
+        if (pos + n <= buf.size) return
+        var cap = buf.size * 2
+        while (cap < pos + n) cap *= 2
+        buf = buf.copyOf(cap)
     }
-    // Flush any remaining unescaped suffix.
-    if (start < len) append(s, start, len)
-    append('"')
+
+    fun writeByte(b: Int) {
+        ensure(1)
+        buf[pos++] = b.toByte()
+    }
+
+    /** Writes an ASCII-only string byte-for-byte (safe for hex strings and JSON literals). */
+    fun writeAscii(s: String) {
+        val len = s.length
+        ensure(len)
+        for (i in 0 until len) buf[pos++] = s[i].code.toByte()
+    }
+
+    /**
+     * Writes [s] as a JSON string value (with surrounding quotes and proper escaping).
+     *
+     * Uses the same scan-then-flush strategy as the former appendJsonEncoded: skip over
+     * unescaped chars in the fast path, then flush each run via [writeUtf8Run] which handles
+     * multi-byte UTF-8 encoding for non-ASCII characters.
+     */
+    fun writeJsonEncoded(s: String) {
+        ensure(s.length + 2)
+        buf[pos++] = '"'.code.toByte()
+        var start = 0
+        val len = s.length
+        var i = 0
+        while (i < len) {
+            val ch = s[i]
+            if (ch.code >= 0x20 && ch != '"' && ch != '\\') {
+                i++
+                continue
+            }
+            writeUtf8Run(s, start, i)
+            ensure(6)
+            when (ch) {
+                '"' -> {
+                    buf[pos++] = '\\'.code.toByte()
+                    buf[pos++] = '"'.code.toByte()
+                }
+                '\\' -> {
+                    buf[pos++] = '\\'.code.toByte()
+                    buf[pos++] = '\\'.code.toByte()
+                }
+                '\n' -> {
+                    buf[pos++] = '\\'.code.toByte()
+                    buf[pos++] = 'n'.code.toByte()
+                }
+                '\r' -> {
+                    buf[pos++] = '\\'.code.toByte()
+                    buf[pos++] = 'r'.code.toByte()
+                }
+                '\t' -> {
+                    buf[pos++] = '\\'.code.toByte()
+                    buf[pos++] = 't'.code.toByte()
+                }
+                else -> {
+                    buf[pos++] = '\\'.code.toByte()
+                    buf[pos++] = 'u'.code.toByte()
+                    val hex = ch.code.toString(16).padStart(4, '0')
+                    for (c in hex) buf[pos++] = c.code.toByte()
+                }
+            }
+            start = i + 1
+            i++
+        }
+        writeUtf8Run(s, start, len)
+        ensure(1)
+        buf[pos++] = '"'.code.toByte()
+    }
+
+    /** Encodes [s] from index [start] (inclusive) to [end] (exclusive) as UTF-8 bytes. */
+    private fun writeUtf8Run(s: String, start: Int, end: Int) {
+        if (start >= end) return
+        ensure((end - start) * 3) // worst-case 3 bytes per BMP char
+        var j = start
+        while (j < end) {
+            val c = s[j]
+            when {
+                c.code < 0x80 -> buf[pos++] = c.code.toByte()
+                c.code < 0x800 -> {
+                    buf[pos++] = (0xC0 or (c.code shr 6)).toByte()
+                    buf[pos++] = (0x80 or (c.code and 0x3F)).toByte()
+                }
+                c.isHighSurrogate() && j + 1 < end && s[j + 1].isLowSurrogate() -> {
+                    val cp = Character.toCodePoint(c, s[j + 1])
+                    buf[pos++] = (0xF0 or (cp shr 18)).toByte()
+                    buf[pos++] = (0x80 or ((cp shr 12) and 0x3F)).toByte()
+                    buf[pos++] = (0x80 or ((cp shr 6) and 0x3F)).toByte()
+                    buf[pos++] = (0x80 or (cp and 0x3F)).toByte()
+                    j++ // consume the low surrogate
+                }
+                else -> {
+                    buf[pos++] = (0xE0 or (c.code shr 12)).toByte()
+                    buf[pos++] = (0x80 or ((c.code shr 6) and 0x3F)).toByte()
+                    buf[pos++] = (0x80 or (c.code and 0x3F)).toByte()
+                }
+            }
+            j++
+        }
+    }
+
+    fun toByteArray(): ByteArray = buf.copyOf(pos)
 }
 
 fun Event.toJsonObject(): JsonNode {

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -196,6 +196,8 @@ object EventRepository {
             val t3 = System.nanoTime()
             val nowSeconds = System.currentTimeMillis() / 1000
 
+            var buildNs = 0L
+            var sendNs = 0L
             eventEntities.forEach { eventEntity ->
                 val tags = tagsByEvent[eventEntity.id] ?: emptyList()
 
@@ -204,7 +206,13 @@ object EventRepository {
                 if (expiry != null && expiry < nowSeconds) return@forEach
 
                 // Build the EVENT message as a raw JSON string without Jackson intermediaries
-                subscription.connection.trySend(buildEventMessage(subscription.id, eventEntity, tags))
+                val tb = System.nanoTime()
+                val msg = buildEventMessage(subscription.id, eventEntity, tags)
+                val ts = System.nanoTime()
+                subscription.connection.trySend(msg)
+                val te = System.nanoTime()
+                buildNs += ts - tb
+                sendNs += te - ts
             }
             val t4 = System.nanoTime()
             Log.d(
@@ -213,6 +221,7 @@ object EventRepository {
                     "query1=${(t2 - t1) / 1_000_000}ms " +
                     "tags=${(t3 - t2) / 1_000_000}ms " +
                     "send=${(t4 - t3) / 1_000_000}ms " +
+                    "build=${buildNs / 1_000_000}ms trySend=${sendNs / 1_000_000}ms " +
                     "events=${eventEntities.size}",
             )
         }

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -119,12 +119,14 @@ object EventRepository {
           $predicatesSql
             """.trimIndent()
         } else {
-            // Exclude the `json` column — it's ~500 bytes per event and is loaded separately
-            // in subscribe() to avoid 5× query slowdown from fetching large TEXT blobs in bulk.
-            // expiresAt (INTEGER) is included here since it's tiny and needed for the expiry check.
+            // Return '' AS json instead of the real column: Room 2.8 requires the column to be
+            // present for NON-NULL fields, but we don't materialise the actual bytes here —
+            // they're loaded in a separate batch query in subscribe() to avoid the ~5× slowdown
+            // caused by fetching ~500 bytes of JSON text per row in the main event query.
+            // SQLite evaluates the constant '' without reading the json column bytes.
             """
         SELECT EventEntity.id, EventEntity.pubkey, EventEntity.createdAt, EventEntity.kind,
-               EventEntity.content, EventEntity.sig, EventEntity.expiresAt
+               EventEntity.content, EventEntity.sig, EventEntity.expiresAt, '' AS json
           FROM EventEntity EventEntity
           $joinSql
           $predicatesSql

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.EventEntity
+import com.greenart7c3.citrine.database.EventIdAndJson
 import com.greenart7c3.citrine.database.EventWithTags
 import com.greenart7c3.citrine.database.TagEntity
 import com.vitorpamplona.quartz.nip01Core.core.Event
@@ -161,6 +162,21 @@ object EventRepository {
         return database.eventDao().count(rawSql)
     }
 
+    /**
+     * Query results loaded inside the semaphore permit.
+     * Returned to the send loop which runs outside the permit so that DB queries from other
+     * subscriptions are not blocked while we are waiting for the network.
+     */
+    private class QueryData(
+        val eventEntities: List<EventEntity>,
+        val jsonById: Map<String, EventIdAndJson>,
+        val tagsByEvent: Map<String?, List<TagEntity>>,
+        val legacyCount: Int,
+        val t1: Long,
+        val t2: Long,
+        val t3: Long,
+    )
+
     suspend fun subscribe(
         subscription: Subscription,
         filter: EventFilter,
@@ -168,7 +184,8 @@ object EventRepository {
         // Acquire a permit before touching the DB so that at most queryPermits.availablePermits
         // coroutines block on the connection pool at once, eliminating thundering-herd contention.
         val t0 = System.nanoTime()
-        queryPermits.withPermit {
+
+        val data = queryPermits.withPermit {
             val t1 = System.nanoTime()
             if (subscription.count) {
                 val count = countQuery(subscription.appDatabase, filter)
@@ -181,7 +198,7 @@ object EventRepository {
                         ),
                     ),
                 )
-                return@withPermit
+                return@withPermit null
             }
 
             val (sql, params) = createQuery(filter, false)
@@ -190,7 +207,7 @@ object EventRepository {
             // loaded separately below to avoid bloating the main event query from ~12ms to ~66ms.
             val eventEntities = subscription.appDatabase.eventDao().getEventsOnly(rawSql)
             val t2 = System.nanoTime()
-            if (eventEntities.isEmpty()) return@withPermit
+            if (eventEntities.isEmpty()) return@withPermit null
 
             // Batch-load cached JSON for all event IDs (replaces tags query for new events).
             // Chunk to stay under SQLite's 999-variable limit.
@@ -201,7 +218,7 @@ object EventRepository {
 
             // Legacy events (json == "") still need tags for NIP-40 check and ByteWriter fallback.
             val legacyIds = allIds.filter { jsonById[it]?.json.isNullOrEmpty() }
-            val tagsByEvent = if (legacyIds.isNotEmpty()) {
+            val tagsByEvent: Map<String?, List<TagEntity>> = if (legacyIds.isNotEmpty()) {
                 legacyIds.chunked(500) { chunk ->
                     subscription.appDatabase.eventDao().getTagsForEvents(chunk)
                 }.flatten().groupBy { it.pkEvent }
@@ -210,44 +227,51 @@ object EventRepository {
             }
 
             val t3 = System.nanoTime()
-            val nowSeconds = System.currentTimeMillis() / 1000
-            val subIdBytes = subscription.id.encodeToByteArray()
+            QueryData(eventEntities, jsonById, tagsByEvent, legacyIds.size, t1, t2, t3)
+            // Permit is released here — the send loop below runs without holding the permit,
+            // so other subscriptions can start their DB queries while we are waiting to send.
+        } ?: return
 
-            var buildNs = 0L
-            var sendNs = 0L
-            eventEntities.forEach { eventEntity ->
-                // NIP-40 expiration: prefer cached expiresAt, fall back to tag scan for legacy events.
-                val expiry = eventEntity.expiresAt
-                    ?: tagsByEvent[eventEntity.id]?.firstOrNull { it.col0Name == "expiration" }
-                        ?.col1Value?.toLongOrNull()
-                if (expiry != null && expiry < nowSeconds) return@forEach
+        // Send loop runs OUTSIDE the semaphore permit.  Releasing the permit here lets other
+        // subscription coroutines begin their DB work while we are writing to the network.
+        val nowSeconds = System.currentTimeMillis() / 1000
+        val subIdBytes = subscription.id.encodeToByteArray()
 
-                val tb = System.nanoTime()
-                val eventJson = jsonById[eventEntity.id]?.json ?: ""
-                val bytes = if (eventJson.isNotEmpty()) {
-                    // Fast path: one native encodeToByteArray() + three arraycopy calls.
-                    buildCachedEventMessageBytes(subIdBytes, eventJson)
-                } else {
-                    // Legacy path: ByteWriter char-by-char encoder for pre-migration events.
-                    buildEventMessageBytes(subscription.id, eventEntity, tagsByEvent[eventEntity.id] ?: emptyList())
-                }
-                val ts = System.nanoTime()
-                subscription.connection.trySend(Frame.Text(true, bytes))
-                val te = System.nanoTime()
-                buildNs += ts - tb
-                sendNs += te - ts
+        var buildNs = 0L
+        var sendNs = 0L
+        for (eventEntity in data.eventEntities) {
+            // NIP-40 expiration: prefer cached expiresAt, fall back to tag scan for legacy events.
+            val expiry = eventEntity.expiresAt
+                ?: data.tagsByEvent[eventEntity.id]?.firstOrNull { it.col0Name == "expiration" }
+                    ?.col1Value?.toLongOrNull()
+            if (expiry != null && expiry < nowSeconds) continue
+
+            val tb = System.nanoTime()
+            val eventJson = data.jsonById[eventEntity.id]?.json ?: ""
+            val bytes = if (eventJson.isNotEmpty()) {
+                // Fast path: one native encodeToByteArray() + three arraycopy calls.
+                buildCachedEventMessageBytes(subIdBytes, eventJson)
+            } else {
+                // Legacy path: ByteWriter char-by-char encoder for pre-migration events.
+                buildEventMessageBytes(subscription.id, eventEntity, data.tagsByEvent[eventEntity.id] ?: emptyList())
             }
-            val t4 = System.nanoTime()
-            Log.d(
-                Citrine.TAG,
-                "subscribe phases: semWait=${(t1 - t0) / 1_000_000}ms " +
-                    "query1=${(t2 - t1) / 1_000_000}ms " +
-                    "json=${(t3 - t2) / 1_000_000}ms " +
-                    "send=${(t4 - t3) / 1_000_000}ms " +
-                    "build=${buildNs / 1_000_000}ms trySend=${sendNs / 1_000_000}ms " +
-                    "events=${eventEntities.size} legacy=${legacyIds.size}",
-            )
+            val ts = System.nanoTime()
+            // Suspending send: waits for channel capacity instead of dropping frames silently.
+            if (!subscription.connection.send(Frame.Text(true, bytes))) break
+            val te = System.nanoTime()
+            buildNs += ts - tb
+            sendNs += te - ts
         }
+        val t4 = System.nanoTime()
+        Log.d(
+            Citrine.TAG,
+            "subscribe phases: semWait=${(data.t1 - t0) / 1_000_000}ms " +
+                "query1=${(data.t2 - data.t1) / 1_000_000}ms " +
+                "json=${(data.t3 - data.t2) / 1_000_000}ms " +
+                "send=${(t4 - data.t3) / 1_000_000}ms " +
+                "build=${buildNs / 1_000_000}ms trySend=${sendNs / 1_000_000}ms " +
+                "events=${data.eventEntities.size} legacy=${data.legacyCount}",
+        )
     }
 }
 

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -161,9 +161,24 @@ object EventRepository {
             return
         }
 
-        val events = query(subscription.appDatabase, filter)
-        events.forEach {
-            val event = it.toEvent()
+        val (sql, params) = createQuery(filter, false)
+        val rawSql = SimpleSQLiteQuery(sql, params.toTypedArray())
+        val eventEntities = subscription.appDatabase.eventDao().getEventsOnly(rawSql)
+        if (eventEntities.isEmpty()) return
+
+        // Batch-load all tags in one query instead of Room's @Relation N+1 pattern.
+        // Chunk to stay under SQLite's 999-variable limit.
+        val tagsByEvent = eventEntities
+            .map { it.id }
+            .chunked(500) { chunk ->
+                subscription.appDatabase.eventDao().getTagsForEvents(chunk)
+            }
+            .flatten()
+            .groupBy { it.pkEvent }
+
+        eventEntities.forEach { eventEntity ->
+            val tags = tagsByEvent[eventEntity.id] ?: emptyList()
+            val event = EventWithTags(eventEntity, tags).toEvent()
             if (!event.isExpired()) {
                 subscription.connection.trySend(
                     subscription.objectMapper.writeValueAsString(

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -324,14 +324,13 @@ private class ByteWriter(initialCapacity: Int) {
     }
 
     /**
-     * Encodes [s] as UTF-8 using the native charset encoder and bulk-copies the result.
-     * Faster than char-by-char loop for long strings such as hex event IDs.
+     * Writes a pure-ASCII string byte-by-byte with zero allocation.
+     * Used for hex IDs/pubkeys/sigs and numeric strings where every char is < 0x80.
      */
     fun writeAscii(s: String) {
-        val bytes = s.encodeToByteArray()
-        ensure(bytes.size)
-        System.arraycopy(bytes, 0, buf, pos, bytes.size)
-        pos += bytes.size
+        val len = s.length
+        ensure(len)
+        for (i in 0 until len) buf[pos++] = s[i].code.toByte()
     }
 
     /**
@@ -391,19 +390,47 @@ private class ByteWriter(initialCapacity: Int) {
     }
 
     /**
-     * Encodes [s][start..end) as UTF-8 via the JDK's native charset encoder and bulk-copies
-     * the result into [buf].  [CharBuffer.wrap] avoids a [String.substring] allocation.
-     * The returned [java.nio.ByteBuffer] is heap-backed (arrayOffset == 0, position == 0).
+     * Encodes [s][start..end) as UTF-8 with zero allocation.
+     *
+     * Reserves [3 × (end − start)] bytes up front (safe: surrogate pairs produce 4 bytes
+     * across 2 chars = 2 bytes/char, unpaired surrogates produce 3 bytes/char).
+     * Handles BMP chars and surrogate pairs; unpaired surrogates are encoded as-is (3 bytes).
      */
     private fun writeUtf8Run(s: String, start: Int, end: Int) {
         if (start >= end) return
-        val bb = java.nio.charset.StandardCharsets.UTF_8.encode(
-            java.nio.CharBuffer.wrap(s, start, end),
-        )
-        val len = bb.limit()
-        ensure(len)
-        System.arraycopy(bb.array(), bb.arrayOffset(), buf, pos, len)
-        pos += len
+        ensure((end - start) * 3)
+        var i = start
+        while (i < end) {
+            val cp = s[i].code
+            when {
+                cp < 0x80 -> buf[pos++] = cp.toByte()
+                cp < 0x800 -> {
+                    buf[pos++] = (0xC0 or (cp ushr 6)).toByte()
+                    buf[pos++] = (0x80 or (cp and 0x3F)).toByte()
+                }
+                cp in 0xD800..0xDBFF && i + 1 < end -> {
+                    val low = s[i + 1].code
+                    if (low in 0xDC00..0xDFFF) {
+                        val cp32 = 0x10000 + ((cp - 0xD800) shl 10) + (low - 0xDC00)
+                        buf[pos++] = (0xF0 or (cp32 ushr 18)).toByte()
+                        buf[pos++] = (0x80 or ((cp32 ushr 12) and 0x3F)).toByte()
+                        buf[pos++] = (0x80 or ((cp32 ushr 6) and 0x3F)).toByte()
+                        buf[pos++] = (0x80 or (cp32 and 0x3F)).toByte()
+                        i += 2
+                        continue
+                    }
+                    buf[pos++] = (0xE0 or (cp ushr 12)).toByte()
+                    buf[pos++] = (0x80 or ((cp ushr 6) and 0x3F)).toByte()
+                    buf[pos++] = (0x80 or (cp and 0x3F)).toByte()
+                }
+                else -> {
+                    buf[pos++] = (0xE0 or (cp ushr 12)).toByte()
+                    buf[pos++] = (0x80 or ((cp ushr 6) and 0x3F)).toByte()
+                    buf[pos++] = (0x80 or (cp and 0x3F)).toByte()
+                }
+            }
+            i++
+        }
     }
 
     fun toByteArray(): ByteArray = buf.copyOf(pos)

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -1,9 +1,7 @@
 package com.greenart7c3.citrine.server
 
-import android.util.Log
 import androidx.sqlite.db.SimpleSQLiteQuery
 import com.fasterxml.jackson.databind.JsonNode
-import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.EventWithTags
 import com.greenart7c3.citrine.database.toEvent
@@ -167,7 +165,6 @@ object EventRepository {
         events.forEach {
             val event = it.toEvent()
             if (!event.isExpired()) {
-                Log.d(Citrine.TAG, "sending event ${event.id} subscription ${subscription.id} filter $filter")
                 subscription.connection.trySend(
                     subscription.objectMapper.writeValueAsString(
                         listOf(

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -392,25 +392,28 @@ private class ByteWriter(initialCapacity: Int) {
     /**
      * Encodes [s][start..end) as UTF-8 with zero allocation.
      *
-     * Reserves [3 × (end − start)] bytes up front (safe: surrogate pairs produce 4 bytes
-     * across 2 chars = 2 bytes/char, unpaired surrogates produce 3 bytes/char).
+     * Pre-reserves [end − start] bytes (sufficient for all-ASCII, the common case).
+     * Each non-ASCII code-unit calls [ensure] for the extra bytes it needs, so resize only
+     * happens when the content actually contains multi-byte characters.
      * Handles BMP chars and surrogate pairs; unpaired surrogates are encoded as-is (3 bytes).
      */
     private fun writeUtf8Run(s: String, start: Int, end: Int) {
         if (start >= end) return
-        ensure((end - start) * 3)
+        ensure(end - start) // fast path: enough for pure-ASCII
         var i = start
         while (i < end) {
             val cp = s[i].code
             when {
                 cp < 0x80 -> buf[pos++] = cp.toByte()
                 cp < 0x800 -> {
+                    ensure(2)
                     buf[pos++] = (0xC0 or (cp ushr 6)).toByte()
                     buf[pos++] = (0x80 or (cp and 0x3F)).toByte()
                 }
                 cp in 0xD800..0xDBFF && i + 1 < end -> {
                     val low = s[i + 1].code
                     if (low in 0xDC00..0xDFFF) {
+                        ensure(4)
                         val cp32 = 0x10000 + ((cp - 0xD800) shl 10) + (low - 0xDC00)
                         buf[pos++] = (0xF0 or (cp32 ushr 18)).toByte()
                         buf[pos++] = (0x80 or ((cp32 ushr 12) and 0x3F)).toByte()
@@ -419,11 +422,13 @@ private class ByteWriter(initialCapacity: Int) {
                         i += 2
                         continue
                     }
+                    ensure(3)
                     buf[pos++] = (0xE0 or (cp ushr 12)).toByte()
                     buf[pos++] = (0x80 or ((cp ushr 6) and 0x3F)).toByte()
                     buf[pos++] = (0x80 or (cp and 0x3F)).toByte()
                 }
                 else -> {
+                    ensure(3)
                     buf[pos++] = (0xE0 or (cp ushr 12)).toByte()
                     buf[pos++] = (0x80 or ((cp ushr 6) and 0x3F)).toByte()
                     buf[pos++] = (0x80 or (cp and 0x3F)).toByte()

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -10,8 +10,19 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
 import kotlin.collections.isNotEmpty
 import kotlin.collections.joinToString
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 
 object EventRepository {
+    // Limit concurrent DB access to avoid thundering-herd on the WAL reader connection pool.
+    // Room's default WAL pool is 2 connections; without this semaphore, 100+ subscription
+    // coroutines all block waiting for a connection, causing massive lock contention and
+    // inflating per-query latency from ~5ms to ~180ms. Capping at availableProcessors()
+    // (min 2, max 4) means at most that many threads fight for connections at once.
+    private val queryPermits = Semaphore(
+        permits = Runtime.getRuntime().availableProcessors().coerceIn(2, 4),
+    )
+
     fun createQuery(
         filter: EventFilter,
         count: Boolean,
@@ -141,50 +152,54 @@ object EventRepository {
         return database.eventDao().count(rawSql)
     }
 
-    fun subscribe(
+    suspend fun subscribe(
         subscription: Subscription,
         filter: EventFilter,
     ) {
-        if (subscription.count) {
-            val count = countQuery(subscription.appDatabase, filter)
-            subscription.connection.trySend(
-                subscription.objectMapper.writeValueAsString(
-                    listOf(
-                        "COUNT",
-                        subscription.id,
-                        CountResult(count).toJson(),
+        // Acquire a permit before touching the DB so that at most queryPermits.availablePermits
+        // coroutines block on the connection pool at once, eliminating thundering-herd contention.
+        queryPermits.withPermit {
+            if (subscription.count) {
+                val count = countQuery(subscription.appDatabase, filter)
+                subscription.connection.trySend(
+                    subscription.objectMapper.writeValueAsString(
+                        listOf(
+                            "COUNT",
+                            subscription.id,
+                            CountResult(count).toJson(),
+                        ),
                     ),
-                ),
-            )
-            return
-        }
-
-        val (sql, params) = createQuery(filter, false)
-        val rawSql = SimpleSQLiteQuery(sql, params.toTypedArray())
-        val eventEntities = subscription.appDatabase.eventDao().getEventsOnly(rawSql)
-        if (eventEntities.isEmpty()) return
-
-        // Batch-load all tags in one query instead of Room's @Relation N+1 pattern.
-        // Chunk to stay under SQLite's 999-variable limit.
-        val tagsByEvent = eventEntities
-            .map { it.id }
-            .chunked(500) { chunk ->
-                subscription.appDatabase.eventDao().getTagsForEvents(chunk)
+                )
+                return@withPermit
             }
-            .flatten()
-            .groupBy { it.pkEvent }
 
-        val nowSeconds = System.currentTimeMillis() / 1000
+            val (sql, params) = createQuery(filter, false)
+            val rawSql = SimpleSQLiteQuery(sql, params.toTypedArray())
+            val eventEntities = subscription.appDatabase.eventDao().getEventsOnly(rawSql)
+            if (eventEntities.isEmpty()) return@withPermit
 
-        eventEntities.forEach { eventEntity ->
-            val tags = tagsByEvent[eventEntity.id] ?: emptyList()
+            // Batch-load all tags in one query instead of Room's @Relation N+1 pattern.
+            // Chunk to stay under SQLite's 999-variable limit.
+            val tagsByEvent = eventEntities
+                .map { it.id }
+                .chunked(500) { chunk ->
+                    subscription.appDatabase.eventDao().getTagsForEvents(chunk)
+                }
+                .flatten()
+                .groupBy { it.pkEvent }
 
-            // Check NIP-40 expiration directly on tags — avoids allocating a full Event object
-            val expiry = tags.firstOrNull { it.col0Name == "expiration" }?.col1Value?.toLongOrNull()
-            if (expiry != null && expiry < nowSeconds) return@forEach
+            val nowSeconds = System.currentTimeMillis() / 1000
 
-            // Build the EVENT message as a raw JSON string without Jackson intermediaries
-            subscription.connection.trySend(buildEventMessage(subscription.id, eventEntity, tags))
+            eventEntities.forEach { eventEntity ->
+                val tags = tagsByEvent[eventEntity.id] ?: emptyList()
+
+                // Check NIP-40 expiration directly on tags — avoids allocating a full Event object
+                val expiry = tags.firstOrNull { it.col0Name == "expiration" }?.col1Value?.toLongOrNull()
+                if (expiry != null && expiry < nowSeconds) return@forEach
+
+                // Build the EVENT message as a raw JSON string without Jackson intermediaries
+                subscription.connection.trySend(buildEventMessage(subscription.id, eventEntity, tags))
+            }
         }
     }
 }

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -234,27 +234,40 @@ object EventRepository {
     }
 }
 
+// Pre-computed UTF-8 bytes for invariant JSON structural fragments.
+// System.arraycopy from these constants is faster than encoding literal strings per-event.
+private val J_EVENT_OPEN = "[\"EVENT\",".encodeToByteArray()
+private val J_ID_OPEN = ",{\"id\":\"".encodeToByteArray()
+private val J_PUBKEY_OPEN = "\",\"pubkey\":\"".encodeToByteArray()
+private val J_CREATED_AT_OPEN = "\",\"created_at\":".encodeToByteArray()
+private val J_KIND_OPEN = ",\"kind\":".encodeToByteArray()
+private val J_TAGS_OPEN = ",\"tags\":[".encodeToByteArray()
+private val J_CONTENT_OPEN = "],\"content\":".encodeToByteArray()
+private val J_SIG_OPEN = ",\"sig\":\"".encodeToByteArray()
+private val J_EVENT_CLOSE = "\"}]".encodeToByteArray()
+
 /**
  * Builds ["EVENT","<subId>",{event}] directly as a UTF-8 [ByteArray].
  *
  * Writing bytes once (instead of writing chars to a StringBuilder then re-encoding to bytes
  * inside Frame.Text(String)) eliminates a full second O(N) pass over every character.
+ * Structural JSON fragments are pre-computed constants copied via System.arraycopy.
  */
 private fun buildEventMessageBytes(subId: String, entity: EventEntity, tags: List<TagEntity>): ByteArray {
     val estSize = 120 + entity.id.length + entity.pubkey.length + entity.sig.length +
         entity.content.length + tags.sumOf { 6 + (it.col0Name?.length ?: 0) + (it.col1Value?.length ?: 0) }
     val w = ByteWriter(estSize)
-    w.writeAscii("[\"EVENT\",")
+    w.writeRaw(J_EVENT_OPEN)
     w.writeJsonEncoded(subId)
-    w.writeAscii(",{\"id\":\"")
+    w.writeRaw(J_ID_OPEN)
     w.writeAscii(entity.id)
-    w.writeAscii("\",\"pubkey\":\"")
+    w.writeRaw(J_PUBKEY_OPEN)
     w.writeAscii(entity.pubkey)
-    w.writeAscii("\",\"created_at\":")
+    w.writeRaw(J_CREATED_AT_OPEN)
     w.writeAscii(entity.createdAt.toString())
-    w.writeAscii(",\"kind\":")
+    w.writeRaw(J_KIND_OPEN)
     w.writeAscii(entity.kind.toString())
-    w.writeAscii(",\"tags\":[")
+    w.writeRaw(J_TAGS_OPEN)
     tags.forEachIndexed { idx, tag ->
         if (idx > 0) w.writeByte(','.code)
         w.writeByte('['.code)
@@ -272,11 +285,11 @@ private fun buildEventMessageBytes(subId: String, entity: EventEntity, tags: Lis
         tag.col4Plus.forEach { part(it) }
         w.writeByte(']'.code)
     }
-    w.writeAscii("],\"content\":")
+    w.writeRaw(J_CONTENT_OPEN)
     w.writeJsonEncoded(entity.content)
-    w.writeAscii(",\"sig\":\"")
+    w.writeRaw(J_SIG_OPEN)
     w.writeAscii(entity.sig)
-    w.writeAscii("\"}]")
+    w.writeRaw(J_EVENT_CLOSE)
     return w.toByteArray()
 }
 
@@ -303,19 +316,29 @@ private class ByteWriter(initialCapacity: Int) {
         buf[pos++] = b.toByte()
     }
 
-    /** Writes an ASCII-only string byte-for-byte (safe for hex strings and JSON literals). */
+    /** Copies a pre-encoded [ByteArray] directly via [System.arraycopy] — no encoding overhead. */
+    fun writeRaw(bytes: ByteArray) {
+        ensure(bytes.size)
+        System.arraycopy(bytes, 0, buf, pos, bytes.size)
+        pos += bytes.size
+    }
+
+    /**
+     * Encodes [s] as UTF-8 using the native charset encoder and bulk-copies the result.
+     * Faster than char-by-char loop for long strings such as hex event IDs.
+     */
     fun writeAscii(s: String) {
-        val len = s.length
-        ensure(len)
-        for (i in 0 until len) buf[pos++] = s[i].code.toByte()
+        val bytes = s.encodeToByteArray()
+        ensure(bytes.size)
+        System.arraycopy(bytes, 0, buf, pos, bytes.size)
+        pos += bytes.size
     }
 
     /**
      * Writes [s] as a JSON string value (with surrounding quotes and proper escaping).
      *
-     * Uses the same scan-then-flush strategy as the former appendJsonEncoded: skip over
-     * unescaped chars in the fast path, then flush each run via [writeUtf8Run] which handles
-     * multi-byte UTF-8 encoding for non-ASCII characters.
+     * Scans for characters that need escaping; flushes unescaped runs via [writeUtf8Run]
+     * which uses the JDK's native UTF-8 encoder for bulk byte production.
      */
     fun writeJsonEncoded(s: String) {
         ensure(s.length + 2)
@@ -367,35 +390,20 @@ private class ByteWriter(initialCapacity: Int) {
         buf[pos++] = '"'.code.toByte()
     }
 
-    /** Encodes [s] from index [start] (inclusive) to [end] (exclusive) as UTF-8 bytes. */
+    /**
+     * Encodes [s][start..end) as UTF-8 via the JDK's native charset encoder and bulk-copies
+     * the result into [buf].  [CharBuffer.wrap] avoids a [String.substring] allocation.
+     * The returned [java.nio.ByteBuffer] is heap-backed (arrayOffset == 0, position == 0).
+     */
     private fun writeUtf8Run(s: String, start: Int, end: Int) {
         if (start >= end) return
-        ensure((end - start) * 3) // worst-case 3 bytes per BMP char
-        var j = start
-        while (j < end) {
-            val c = s[j]
-            when {
-                c.code < 0x80 -> buf[pos++] = c.code.toByte()
-                c.code < 0x800 -> {
-                    buf[pos++] = (0xC0 or (c.code shr 6)).toByte()
-                    buf[pos++] = (0x80 or (c.code and 0x3F)).toByte()
-                }
-                c.isHighSurrogate() && j + 1 < end && s[j + 1].isLowSurrogate() -> {
-                    val cp = Character.toCodePoint(c, s[j + 1])
-                    buf[pos++] = (0xF0 or (cp shr 18)).toByte()
-                    buf[pos++] = (0x80 or ((cp shr 12) and 0x3F)).toByte()
-                    buf[pos++] = (0x80 or ((cp shr 6) and 0x3F)).toByte()
-                    buf[pos++] = (0x80 or (cp and 0x3F)).toByte()
-                    j++ // consume the low surrogate
-                }
-                else -> {
-                    buf[pos++] = (0xE0 or (c.code shr 12)).toByte()
-                    buf[pos++] = (0x80 or ((c.code shr 6) and 0x3F)).toByte()
-                    buf[pos++] = (0x80 or (c.code and 0x3F)).toByte()
-                }
-            }
-            j++
-        }
+        val bb = java.nio.charset.StandardCharsets.UTF_8.encode(
+            java.nio.CharBuffer.wrap(s, start, end),
+        )
+        val len = bb.limit()
+        ensure(len)
+        System.arraycopy(bb.array(), bb.arrayOffset(), buf, pos, len)
+        pos += len
     }
 
     fun toByteArray(): ByteArray = buf.copyOf(pos)

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -119,8 +119,12 @@ object EventRepository {
           $predicatesSql
             """.trimIndent()
         } else {
+            // Exclude the `json` column — it's ~500 bytes per event and is loaded separately
+            // in subscribe() to avoid 5× query slowdown from fetching large TEXT blobs in bulk.
+            // expiresAt (INTEGER) is included here since it's tiny and needed for the expiry check.
             """
-        SELECT EventEntity.*
+        SELECT EventEntity.id, EventEntity.pubkey, EventEntity.createdAt, EventEntity.kind,
+               EventEntity.content, EventEntity.sig, EventEntity.expiresAt
           FROM EventEntity EventEntity
           $joinSql
           $predicatesSql
@@ -180,15 +184,23 @@ object EventRepository {
 
             val (sql, params) = createQuery(filter, false)
             val rawSql = SimpleSQLiteQuery(sql, params.toTypedArray())
+            // getEventsOnly uses a SELECT that excludes the large `json` TEXT column; it is
+            // loaded separately below to avoid bloating the main event query from ~12ms to ~66ms.
             val eventEntities = subscription.appDatabase.eventDao().getEventsOnly(rawSql)
             val t2 = System.nanoTime()
             if (eventEntities.isEmpty()) return@withPermit
 
-            // Events inserted before migration 12 have json == ""; those need tag-based fallback.
-            val legacyEventIds = eventEntities.filter { it.json.isEmpty() }.map { it.id }
-            val tagsByEvent = if (legacyEventIds.isNotEmpty()) {
-                // Batch-load tags only for legacy events — chunk to stay under SQLite 999-var limit.
-                legacyEventIds.chunked(500) { chunk ->
+            // Batch-load cached JSON for all event IDs (replaces tags query for new events).
+            // Chunk to stay under SQLite's 999-variable limit.
+            val allIds = eventEntities.map { it.id }
+            val jsonById = allIds.chunked(500) { chunk ->
+                subscription.appDatabase.eventDao().getEventJsonForIds(chunk)
+            }.flatten().associateBy { it.id }
+
+            // Legacy events (json == "") still need tags for NIP-40 check and ByteWriter fallback.
+            val legacyIds = allIds.filter { jsonById[it]?.json.isNullOrEmpty() }
+            val tagsByEvent = if (legacyIds.isNotEmpty()) {
+                legacyIds.chunked(500) { chunk ->
                     subscription.appDatabase.eventDao().getTagsForEvents(chunk)
                 }.flatten().groupBy { it.pkEvent }
             } else {
@@ -197,7 +209,6 @@ object EventRepository {
 
             val t3 = System.nanoTime()
             val nowSeconds = System.currentTimeMillis() / 1000
-            // Pre-encode the subscription ID bytes once for the fast-path frame builder.
             val subIdBytes = subscription.id.encodeToByteArray()
 
             var buildNs = 0L
@@ -205,21 +216,20 @@ object EventRepository {
             eventEntities.forEach { eventEntity ->
                 // NIP-40 expiration: prefer cached expiresAt, fall back to tag scan for legacy events.
                 val expiry = eventEntity.expiresAt
-                    ?: tagsByEvent[eventEntity.id]?.firstOrNull { it.col0Name == "expiration" }?.col1Value?.toLongOrNull()
+                    ?: tagsByEvent[eventEntity.id]?.firstOrNull { it.col0Name == "expiration" }
+                        ?.col1Value?.toLongOrNull()
                 if (expiry != null && expiry < nowSeconds) return@forEach
 
                 val tb = System.nanoTime()
-                val bytes = if (eventEntity.json.isNotEmpty()) {
-                    // Fast path: assemble frame bytes from the cached JSON string using one native
-                    // encodeToByteArray() call — avoids the per-char ByteWriter encoding loop.
-                    buildCachedEventMessageBytes(subIdBytes, eventEntity.json)
+                val eventJson = jsonById[eventEntity.id]?.json ?: ""
+                val bytes = if (eventJson.isNotEmpty()) {
+                    // Fast path: one native encodeToByteArray() + three arraycopy calls.
+                    buildCachedEventMessageBytes(subIdBytes, eventJson)
                 } else {
-                    // Legacy path: build bytes via ByteWriter for events without cached JSON.
-                    val tags = tagsByEvent[eventEntity.id] ?: emptyList()
-                    buildEventMessageBytes(subscription.id, eventEntity, tags)
+                    // Legacy path: ByteWriter char-by-char encoder for pre-migration events.
+                    buildEventMessageBytes(subscription.id, eventEntity, tagsByEvent[eventEntity.id] ?: emptyList())
                 }
                 val ts = System.nanoTime()
-                // Frame.Text(true, byteArray) uses the bytes as-is with no further encoding.
                 subscription.connection.trySend(Frame.Text(true, bytes))
                 val te = System.nanoTime()
                 buildNs += ts - tb
@@ -230,10 +240,10 @@ object EventRepository {
                 Citrine.TAG,
                 "subscribe phases: semWait=${(t1 - t0) / 1_000_000}ms " +
                     "query1=${(t2 - t1) / 1_000_000}ms " +
-                    "tags=${(t3 - t2) / 1_000_000}ms " +
+                    "json=${(t3 - t2) / 1_000_000}ms " +
                     "send=${(t4 - t3) / 1_000_000}ms " +
                     "build=${buildNs / 1_000_000}ms trySend=${sendNs / 1_000_000}ms " +
-                    "events=${eventEntities.size} legacy=${legacyEventIds.size}",
+                    "events=${eventEntities.size} legacy=${legacyIds.size}",
             )
         }
     }

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -10,6 +10,7 @@ import com.greenart7c3.citrine.database.EventWithTags
 import com.greenart7c3.citrine.database.TagEntity
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
+import io.ktor.websocket.Frame
 import kotlin.collections.isNotEmpty
 import kotlin.collections.joinToString
 import kotlinx.coroutines.sync.Semaphore
@@ -197,6 +198,7 @@ object EventRepository {
             val nowSeconds = System.currentTimeMillis() / 1000
 
             var buildNs = 0L
+            var frameNs = 0L
             var sendNs = 0L
             eventEntities.forEach { eventEntity ->
                 val tags = tagsByEvent[eventEntity.id] ?: emptyList()
@@ -209,10 +211,14 @@ object EventRepository {
                 val tb = System.nanoTime()
                 val msg = buildEventMessage(subscription.id, eventEntity, tags)
                 val ts = System.nanoTime()
-                subscription.connection.trySend(msg)
+                // Pre-encode String→ByteArray once here; Frame.Text(String) would do this anyway.
+                val frame = Frame.Text(msg)
+                val tf = System.nanoTime()
+                subscription.connection.trySend(frame)
                 val te = System.nanoTime()
                 buildNs += ts - tb
-                sendNs += te - ts
+                frameNs += tf - ts
+                sendNs += te - tf
             }
             val t4 = System.nanoTime()
             Log.d(
@@ -221,7 +227,7 @@ object EventRepository {
                     "query1=${(t2 - t1) / 1_000_000}ms " +
                     "tags=${(t3 - t2) / 1_000_000}ms " +
                     "send=${(t4 - t3) / 1_000_000}ms " +
-                    "build=${buildNs / 1_000_000}ms trySend=${sendNs / 1_000_000}ms " +
+                    "build=${buildNs / 1_000_000}ms frame=${frameNs / 1_000_000}ms trySend=${sendNs / 1_000_000}ms " +
                     "events=${eventEntities.size}",
             )
         }
@@ -270,23 +276,41 @@ private fun StringBuilder.appendTagParts(tag: TagEntity) {
     tag.col4Plus.forEach { part(it) }
 }
 
-/** Appends [s] as a JSON-encoded string (with surrounding quotes and proper escaping). */
+/**
+ * Appends [s] as a JSON-encoded string (surrounding quotes + proper escaping).
+ *
+ * Uses a bulk-copy strategy: scan for characters that need escaping, and flush
+ * the unescaped runs between them with a single [StringBuilder.append] call that
+ * resolves to [System.arraycopy] internally — orders of magnitude faster than the
+ * previous char-by-char append loop for typical content with few or no special chars.
+ */
 private fun StringBuilder.appendJsonEncoded(s: String) {
     append('"')
-    for (ch in s) {
-        when {
-            ch == '"' -> append("\\\"")
-            ch == '\\' -> append("\\\\")
-            ch == '\n' -> append("\\n")
-            ch == '\r' -> append("\\r")
-            ch == '\t' -> append("\\t")
-            ch.code < 0x20 -> {
-                append("\\u")
-                append(ch.code.toString(16).padStart(4, '0'))
-            }
-            else -> append(ch)
+    var start = 0
+    val len = s.length
+    var i = 0
+    while (i < len) {
+        val ch = s[i]
+        // Fast path: printable ASCII that isn't " or \ needs no escaping — keep scanning.
+        if (ch.code >= 0x20 && ch != '"' && ch != '\\') {
+            i++
+            continue
         }
+        // Flush the unescaped run [start, i) as a single bulk copy (System.arraycopy).
+        if (i > start) append(s, start, i)
+        when (ch) {
+            '"' -> append("\\\"")
+            '\\' -> append("\\\\")
+            '\n' -> append("\\n")
+            '\r' -> append("\\r")
+            '\t' -> append("\\t")
+            else -> append("\\u").append(ch.code.toString(16).padStart(4, '0'))
+        }
+        start = i + 1
+        i++
     }
+    // Flush any remaining unescaped suffix.
+    if (start < len) append(s, start, len)
     append('"')
 }
 

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.EventEntity
-import com.greenart7c3.citrine.database.EventIdAndJson
 import com.greenart7c3.citrine.database.EventWithTags
 import com.greenart7c3.citrine.database.TagEntity
 import com.vitorpamplona.quartz.nip01Core.core.Event
@@ -120,14 +119,9 @@ object EventRepository {
           $predicatesSql
             """.trimIndent()
         } else {
-            // Return '' AS json instead of the real column: Room 2.8 requires the column to be
-            // present for NON-NULL fields, but we don't materialise the actual bytes here —
-            // they're loaded in a separate batch query in subscribe() to avoid the ~5× slowdown
-            // caused by fetching ~500 bytes of JSON text per row in the main event query.
-            // SQLite evaluates the constant '' without reading the json column bytes.
             """
         SELECT EventEntity.id, EventEntity.pubkey, EventEntity.createdAt, EventEntity.kind,
-               EventEntity.content, EventEntity.sig, EventEntity.expiresAt, '' AS json
+               EventEntity.content, EventEntity.sig, EventEntity.expiresAt, EventEntity.json
           FROM EventEntity EventEntity
           $joinSql
           $predicatesSql
@@ -169,12 +163,10 @@ object EventRepository {
      */
     private class QueryData(
         val eventEntities: List<EventEntity>,
-        val jsonById: Map<String, EventIdAndJson>,
         val tagsByEvent: Map<String?, List<TagEntity>>,
         val legacyCount: Int,
         val t1: Long,
         val t2: Long,
-        val t3: Long,
     )
 
     suspend fun subscribe(
@@ -203,21 +195,12 @@ object EventRepository {
 
             val (sql, params) = createQuery(filter, false)
             val rawSql = SimpleSQLiteQuery(sql, params.toTypedArray())
-            // getEventsOnly uses a SELECT that excludes the large `json` TEXT column; it is
-            // loaded separately below to avoid bloating the main event query from ~12ms to ~66ms.
             val eventEntities = subscription.appDatabase.eventDao().getEventsOnly(rawSql)
             val t2 = System.nanoTime()
             if (eventEntities.isEmpty()) return@withPermit null
 
-            // Batch-load cached JSON for all event IDs (replaces tags query for new events).
-            // Chunk to stay under SQLite's 999-variable limit.
-            val allIds = eventEntities.map { it.id }
-            val jsonById = allIds.chunked(500) { chunk ->
-                subscription.appDatabase.eventDao().getEventJsonForIds(chunk)
-            }.flatten().associateBy { it.id }
-
             // Legacy events (json == "") still need tags for NIP-40 check and ByteWriter fallback.
-            val legacyIds = allIds.filter { jsonById[it]?.json.isNullOrEmpty() }
+            val legacyIds = eventEntities.filter { it.json.isEmpty() }.map { it.id }
             val tagsByEvent: Map<String?, List<TagEntity>> = if (legacyIds.isNotEmpty()) {
                 legacyIds.chunked(500) { chunk ->
                     subscription.appDatabase.eventDao().getTagsForEvents(chunk)
@@ -226,8 +209,7 @@ object EventRepository {
                 emptyMap()
             }
 
-            val t3 = System.nanoTime()
-            QueryData(eventEntities, jsonById, tagsByEvent, legacyIds.size, t1, t2, t3)
+            QueryData(eventEntities, tagsByEvent, legacyIds.size, t1, t2)
             // Permit is released here — the send loop below runs without holding the permit,
             // so other subscriptions can start their DB queries while we are waiting to send.
         } ?: return
@@ -248,23 +230,21 @@ object EventRepository {
                     ?.col1Value?.toLongOrNull()
             if (expiry != null && expiry < nowSeconds) continue
 
-            val eventJson = data.jsonById[eventEntity.id]?.json ?: ""
-            val bytes = if (eventJson.isNotEmpty()) {
+            val bytes = if (eventEntity.json.isNotEmpty()) {
                 // Fast path: one native encodeToByteArray() + three arraycopy calls.
-                buildCachedEventMessageBytes(subIdBytes, eventJson)
+                buildCachedEventMessageBytes(subIdBytes, eventEntity.json)
             } else {
                 // Legacy path: ByteWriter char-by-char encoder for pre-migration events.
                 buildEventMessageBytes(subscription.id, eventEntity, data.tagsByEvent[eventEntity.id] ?: emptyList())
             }
             subscription.connection.trySend(Frame.Text(true, bytes))
         }
-        val t4 = System.nanoTime()
+        val t3 = System.nanoTime()
         Log.d(
             Citrine.TAG,
             "subscribe phases: semWait=${(data.t1 - t0) / 1_000_000}ms " +
-                "query1=${(data.t2 - data.t1) / 1_000_000}ms " +
-                "json=${(data.t3 - data.t2) / 1_000_000}ms " +
-                "send=${(t4 - data.t3) / 1_000_000}ms " +
+                "query=${(data.t2 - data.t1) / 1_000_000}ms " +
+                "send=${(t3 - data.t2) / 1_000_000}ms " +
                 "events=${data.eventEntities.size} legacy=${data.legacyCount}",
         )
     }

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -184,41 +184,46 @@ object EventRepository {
             val t2 = System.nanoTime()
             if (eventEntities.isEmpty()) return@withPermit
 
-            // Batch-load all tags in one query instead of Room's @Relation N+1 pattern.
-            // Chunk to stay under SQLite's 999-variable limit.
-            val tagsByEvent = eventEntities
-                .map { it.id }
-                .chunked(500) { chunk ->
+            // Events inserted before migration 12 have json == ""; those need tag-based fallback.
+            val legacyEventIds = eventEntities.filter { it.json.isEmpty() }.map { it.id }
+            val tagsByEvent = if (legacyEventIds.isNotEmpty()) {
+                // Batch-load tags only for legacy events — chunk to stay under SQLite 999-var limit.
+                legacyEventIds.chunked(500) { chunk ->
                     subscription.appDatabase.eventDao().getTagsForEvents(chunk)
-                }
-                .flatten()
-                .groupBy { it.pkEvent }
+                }.flatten().groupBy { it.pkEvent }
+            } else {
+                emptyMap()
+            }
 
             val t3 = System.nanoTime()
             val nowSeconds = System.currentTimeMillis() / 1000
+            // Pre-encode the subscription ID bytes once for the fast-path frame builder.
+            val subIdBytes = subscription.id.encodeToByteArray()
 
             var buildNs = 0L
-            var frameNs = 0L
             var sendNs = 0L
             eventEntities.forEach { eventEntity ->
-                val tags = tagsByEvent[eventEntity.id] ?: emptyList()
-
-                // Check NIP-40 expiration directly on tags — avoids allocating a full Event object
-                val expiry = tags.firstOrNull { it.col0Name == "expiration" }?.col1Value?.toLongOrNull()
+                // NIP-40 expiration: prefer cached expiresAt, fall back to tag scan for legacy events.
+                val expiry = eventEntity.expiresAt
+                    ?: tagsByEvent[eventEntity.id]?.firstOrNull { it.col0Name == "expiration" }?.col1Value?.toLongOrNull()
                 if (expiry != null && expiry < nowSeconds) return@forEach
 
-                // Build the EVENT message bytes directly — avoids String→ByteArray re-encoding.
                 val tb = System.nanoTime()
-                val bytes = buildEventMessageBytes(subscription.id, eventEntity, tags)
+                val bytes = if (eventEntity.json.isNotEmpty()) {
+                    // Fast path: assemble frame bytes from the cached JSON string using one native
+                    // encodeToByteArray() call — avoids the per-char ByteWriter encoding loop.
+                    buildCachedEventMessageBytes(subIdBytes, eventEntity.json)
+                } else {
+                    // Legacy path: build bytes via ByteWriter for events without cached JSON.
+                    val tags = tagsByEvent[eventEntity.id] ?: emptyList()
+                    buildEventMessageBytes(subscription.id, eventEntity, tags)
+                }
                 val ts = System.nanoTime()
                 // Frame.Text(true, byteArray) uses the bytes as-is with no further encoding.
-                val frame = Frame.Text(true, bytes)
-                val tf = System.nanoTime()
-                subscription.connection.trySend(frame)
+                subscription.connection.trySend(Frame.Text(true, bytes))
                 val te = System.nanoTime()
                 buildNs += ts - tb
-                frameNs += tf - ts
-                sendNs += te - tf
+                sendNs += te - ts
             }
             val t4 = System.nanoTime()
             Log.d(
@@ -227,8 +232,8 @@ object EventRepository {
                     "query1=${(t2 - t1) / 1_000_000}ms " +
                     "tags=${(t3 - t2) / 1_000_000}ms " +
                     "send=${(t4 - t3) / 1_000_000}ms " +
-                    "build=${buildNs / 1_000_000}ms frame=${frameNs / 1_000_000}ms trySend=${sendNs / 1_000_000}ms " +
-                    "events=${eventEntities.size}",
+                    "build=${buildNs / 1_000_000}ms trySend=${sendNs / 1_000_000}ms " +
+                    "events=${eventEntities.size} legacy=${legacyEventIds.size}",
             )
         }
     }
@@ -236,6 +241,9 @@ object EventRepository {
 
 // Pre-computed UTF-8 bytes for invariant JSON structural fragments.
 // System.arraycopy from these constants is faster than encoding literal strings per-event.
+private val J_CACHED_PREFIX = "[\"EVENT\",\"".encodeToByteArray() // fast-path prefix up to subId
+private val J_CACHED_SEP = "\",".encodeToByteArray() // separator between subId and event JSON
+private val J_CACHED_SUFFIX = "]".encodeToByteArray() // closing bracket
 private val J_EVENT_OPEN = "[\"EVENT\",".encodeToByteArray()
 private val J_ID_OPEN = ",{\"id\":\"".encodeToByteArray()
 private val J_PUBKEY_OPEN = "\",\"pubkey\":\"".encodeToByteArray()
@@ -247,11 +255,38 @@ private val J_SIG_OPEN = ",\"sig\":\"".encodeToByteArray()
 private val J_EVENT_CLOSE = "\"}]".encodeToByteArray()
 
 /**
+ * Fast-path frame builder for events with a pre-serialized [eventJson] cache column.
+ *
+ * Assembles `["EVENT","<subId>",<eventJson>]` via three [System.arraycopy] calls plus one
+ * native [String.encodeToByteArray] for the event JSON — orders of magnitude faster than the
+ * char-by-char [ByteWriter] loop for events that went through the legacy insert path.
+ *
+ * @param subIdBytes pre-encoded subscription ID bytes (computed once per subscribe() call)
+ * @param eventJson  the pre-serialized inner event object stored in [EventEntity.json]
+ */
+private fun buildCachedEventMessageBytes(subIdBytes: ByteArray, eventJson: String): ByteArray {
+    val jsonBytes = eventJson.encodeToByteArray()
+    val total = J_CACHED_PREFIX.size + subIdBytes.size + J_CACHED_SEP.size + jsonBytes.size + J_CACHED_SUFFIX.size
+    val out = ByteArray(total)
+    var pos = 0
+    System.arraycopy(J_CACHED_PREFIX, 0, out, pos, J_CACHED_PREFIX.size)
+    pos += J_CACHED_PREFIX.size
+    System.arraycopy(subIdBytes, 0, out, pos, subIdBytes.size)
+    pos += subIdBytes.size
+    System.arraycopy(J_CACHED_SEP, 0, out, pos, J_CACHED_SEP.size)
+    pos += J_CACHED_SEP.size
+    System.arraycopy(jsonBytes, 0, out, pos, jsonBytes.size)
+    pos += jsonBytes.size
+    System.arraycopy(J_CACHED_SUFFIX, 0, out, pos, J_CACHED_SUFFIX.size)
+    return out
+}
+
+/**
  * Builds ["EVENT","<subId>",{event}] directly as a UTF-8 [ByteArray].
  *
- * Writing bytes once (instead of writing chars to a StringBuilder then re-encoding to bytes
- * inside Frame.Text(String)) eliminates a full second O(N) pass over every character.
- * Structural JSON fragments are pre-computed constants copied via System.arraycopy.
+ * Legacy path for events without a cached [EventEntity.json] column (inserted before
+ * migration 12). Structural JSON fragments are pre-computed constants copied via
+ * [System.arraycopy]; variable fields use the [ByteWriter] char-by-char encoder.
  */
 private fun buildEventMessageBytes(subId: String, entity: EventEntity, tags: List<TagEntity>): ByteArray {
     val estSize = 120 + entity.id.length + entity.pubkey.length + entity.sig.length +

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -3,11 +3,11 @@ package com.greenart7c3.citrine.server
 import androidx.sqlite.db.SimpleSQLiteQuery
 import com.fasterxml.jackson.databind.JsonNode
 import com.greenart7c3.citrine.database.AppDatabase
+import com.greenart7c3.citrine.database.EventEntity
 import com.greenart7c3.citrine.database.EventWithTags
-import com.greenart7c3.citrine.database.toEvent
+import com.greenart7c3.citrine.database.TagEntity
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
-import com.vitorpamplona.quartz.nip40Expiration.isExpired
 import kotlin.collections.isNotEmpty
 import kotlin.collections.joinToString
 
@@ -176,22 +176,81 @@ object EventRepository {
             .flatten()
             .groupBy { it.pkEvent }
 
+        val nowSeconds = System.currentTimeMillis() / 1000
+
         eventEntities.forEach { eventEntity ->
             val tags = tagsByEvent[eventEntity.id] ?: emptyList()
-            val event = EventWithTags(eventEntity, tags).toEvent()
-            if (!event.isExpired()) {
-                subscription.connection.trySend(
-                    subscription.objectMapper.writeValueAsString(
-                        listOf(
-                            "EVENT",
-                            subscription.id,
-                            event.toJsonObject(),
-                        ),
-                    ),
-                )
-            }
+
+            // Check NIP-40 expiration directly on tags — avoids allocating a full Event object
+            val expiry = tags.firstOrNull { it.col0Name == "expiration" }?.col1Value?.toLongOrNull()
+            if (expiry != null && expiry < nowSeconds) return@forEach
+
+            // Build the EVENT message as a raw JSON string without Jackson intermediaries
+            subscription.connection.trySend(buildEventMessage(subscription.id, eventEntity, tags))
         }
     }
+}
+
+/** Builds ["EVENT","<subId>",{event}] without Jackson intermediate objects. */
+private fun buildEventMessage(subId: String, entity: EventEntity, tags: List<TagEntity>): String = buildString(capacity = 1024) {
+    append("[\"EVENT\",")
+    appendJsonEncoded(subId)
+    append(",{\"id\":\"")
+    append(entity.id)
+    append("\",\"pubkey\":\"")
+    append(entity.pubkey)
+    append("\",\"created_at\":")
+    append(entity.createdAt)
+    append(",\"kind\":")
+    append(entity.kind)
+    append(",\"tags\":[")
+    tags.forEachIndexed { i, tag ->
+        if (i > 0) append(',')
+        append('[')
+        appendTagParts(tag)
+        append(']')
+    }
+    append("],\"content\":")
+    appendJsonEncoded(entity.content)
+    append(",\"sig\":\"")
+    append(entity.sig)
+    append("\"}]")
+}
+
+/** Appends the non-null tag parts as a comma-separated JSON string list. */
+private fun StringBuilder.appendTagParts(tag: TagEntity) {
+    var first = true
+    fun part(s: String?) {
+        if (s == null) return
+        if (!first) append(',')
+        first = false
+        appendJsonEncoded(s)
+    }
+    part(tag.col0Name)
+    part(tag.col1Value)
+    part(tag.col2Differentiator)
+    part(tag.col3Amount)
+    tag.col4Plus.forEach { part(it) }
+}
+
+/** Appends [s] as a JSON-encoded string (with surrounding quotes and proper escaping). */
+private fun StringBuilder.appendJsonEncoded(s: String) {
+    append('"')
+    for (ch in s) {
+        when {
+            ch == '"' -> append("\\\"")
+            ch == '\\' -> append("\\\\")
+            ch == '\n' -> append("\\n")
+            ch == '\r' -> append("\\r")
+            ch == '\t' -> append("\\t")
+            ch.code < 0x20 -> {
+                append("\\u")
+                append(ch.code.toString(16).padStart(4, '0'))
+            }
+            else -> append(ch)
+        }
+    }
+    append('"')
 }
 
 fun Event.toJsonObject(): JsonNode {

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventSubscription.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventSubscription.kt
@@ -1,14 +1,16 @@
 package com.greenart7c3.citrine.server
 
 import android.util.Log
-import android.util.LruCache
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.EventWithTags
 import com.greenart7c3.citrine.database.toEvent
 import com.greenart7c3.citrine.utils.isEphemeral
 import io.ktor.server.websocket.WebSocketServerSession
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
@@ -28,32 +30,25 @@ data class Subscription(
 }
 
 object EventSubscription {
-    private val subscriptions = LruCache<String, SubscriptionManager>(500)
+    private val subscriptions = ConcurrentHashMap<String, SubscriptionManager>()
+    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
-    fun getConnection(session: WebSocketServerSession): Connection? = subscriptions.snapshot().values.firstOrNull { it.subscription.connection.session == session }?.subscription?.connection
+    fun getConnection(session: WebSocketServerSession): Connection? = subscriptions.values.firstOrNull { it.subscription.connection.session == session }?.subscription?.connection
 
-    fun count(): Int = subscriptions.size()
+    fun count(): Int = subscriptions.size
 
     fun executeAll(dbEvent: EventWithTags, connection: Connection?) {
         Citrine.instance.applicationScope.launch(Dispatchers.IO) {
             val event = dbEvent.toEvent()
-            val eventJson = event.toJsonObject()
+            val eventJsonStr = objectMapper.writeValueAsString(event.toJsonObject())
             var sentEvent = false
-            subscriptions.snapshot().values.forEach {
-                it.subscription.filters.forEach filter@{ filter ->
-                    if (filter.test(event)) {
-                        it.subscription.connection.trySend(
-                            it.subscription.objectMapper.writeValueAsString(
-                                listOf(
-                                    "EVENT",
-                                    it.subscription.id,
-                                    eventJson,
-                                ),
-                            ),
-                        )
-
-                        sentEvent = true
-                    }
+            subscriptions.values.forEach { manager ->
+                val sub = manager.subscription
+                if (sub.filters.any { filter -> filter.test(event) }) {
+                    val subIdJson = objectMapper.writeValueAsString(sub.id)
+                    sub.connection.trySend("""["EVENT",$subIdJson,$eventJsonStr]""")
+                    sentEvent = true
                 }
             }
             if (event.isEphemeral()) {
@@ -70,28 +65,29 @@ object EventSubscription {
 
     fun closeAll(connectionName: String) {
         Log.d(Citrine.TAG, "finalizing subscriptions from $connectionName")
-        subscriptions.snapshot().entries.forEach { (key, manager) ->
-            if (manager.subscription.connection.name == connectionName) {
-                Log.d(Citrine.TAG, "closing subscription $key")
-                manager.subscription.scope.coroutineContext.cancelChildren()
-                subscriptions.remove(key)
+        val iterator = subscriptions.entries.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (entry.value.subscription.connection.name == connectionName) {
+                Log.d(Citrine.TAG, "closing subscription ${entry.key}")
+                entry.value.subscription.scope.coroutineContext.cancelChildren()
+                iterator.remove()
             }
         }
     }
 
     fun closeAll() {
-        subscriptions.snapshot().keys.forEach {
+        subscriptions.keys.forEach {
             close(it)
         }
     }
 
     fun close(subscriptionId: String) {
-        subscriptions.get(subscriptionId)?.subscription?.scope?.coroutineContext?.cancelChildren()
-        subscriptions.remove(subscriptionId)
+        subscriptions.remove(subscriptionId)?.subscription?.scope?.coroutineContext?.cancelChildren()
     }
 
     @OptIn(DelicateCoroutinesApi::class)
-    fun containsConnection(connection: Connection): Boolean = subscriptions.snapshot().values.any { it.subscription.connection.name == connection.name && !it.subscription.connection.session.outgoing.isClosedForSend }
+    fun containsConnection(connection: Connection): Boolean = subscriptions.values.any { it.subscription.connection.name == connection.name && !it.subscription.connection.session.outgoing.isClosedForSend }
 
     suspend fun subscribe(
         subscriptionId: String,
@@ -112,10 +108,7 @@ object EventSubscription {
                 count,
             ),
         )
-        subscriptions.put(
-            subscriptionId,
-            manager,
-        )
+        subscriptions[subscriptionId] = manager
         manager.execute()
     }
 }

--- a/app/src/main/java/com/greenart7c3/citrine/service/PokeyReceiver.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/PokeyReceiver.kt
@@ -53,7 +53,7 @@ class PokeyReceiver : BroadcastReceiver() {
 
         scope.launch(Dispatchers.IO) {
             try {
-                CustomWebSocketService.server?.innerProcessEvent(Event.fromJson(eventStr), null)
+                CustomWebSocketService.server?.innerProcessEvent(Event.fromJson(eventStr), null, rawJson = eventStr)
             } catch (e: Exception) {
                 Log.e(Citrine.TAG, "Failed to parse Pokey Event", e)
             }


### PR DESCRIPTION
## Summary
This PR significantly improves event subscription performance by introducing a semaphore-based concurrency limiter for database queries and implementing a JSON caching strategy to avoid redundant serialization work.

## Key Changes

### Database & Schema
- **Migration 12**: Added `json` (TEXT) and `expiresAt` (INTEGER) columns to EventEntity
  - `json` stores pre-serialized event JSON to avoid re-encoding on every subscription send
  - `expiresAt` caches NIP-40 expiration timestamps for faster filtering without tag lookups
- Updated AppDatabase version from 11 to 12 with new schema

### Query Performance
- **Semaphore-based concurrency limiting**: Added `queryPermits` semaphore (sized to 2-4 based on CPU cores) to prevent thundering-herd contention on Room's WAL connection pool
  - Reduces per-query latency from ~180ms to ~5ms under high subscription load
  - Limits concurrent DB access to avoid blocking 100+ coroutines on limited connections
- **Removed INNER JOIN on TagEntity**: Replaced with EXISTS subqueries to avoid N-row expansion per event
  - Eliminates need for DISTINCT and reduces query work proportional to tags-per-event
- **Split query strategy**: Main event query now returns only metadata (excluding large `json` column), with JSON batch-loaded separately
  - Reduces main query from ~66ms to ~12ms by avoiding 500-byte JSON text per row

### Event Serialization
- **Fast-path JSON encoding**: New `buildCachedEventMessageBytes()` uses pre-computed UTF-8 byte constants and `System.arraycopy` for cached events
  - Three arraycopy calls + one native encode vs. char-by-char encoding
- **Legacy fallback**: `buildEventMessageBytes()` with custom `ByteWriter` class for pre-migration events
  - Eliminates intermediate String allocation in Frame.Text(String) path
  - Direct UTF-8 encoding with proper JSON escaping and surrogate pair handling
- **Batch JSON loading**: `getEventJsonForIds()` loads pre-serialized JSON in 500-ID chunks to stay under SQLite's 999-variable limit

### Subscription Flow
- Made `subscribe()` function suspend to properly acquire semaphore permits
- Separated DB query phase (inside permit) from send phase (outside permit)
  - Allows other subscriptions to query while current subscription is sending
  - Prevents network I/O from blocking database access
- Added detailed performance logging with phase breakdown (semaphore wait, query, JSON load, send)

### Event Processing
- Updated `innerProcessEvent()` to accept optional `rawJson` parameter
  - Stores original client JSON directly without re-serialization round-trip
  - Saves cost of reconstructing JSON from Event fields
- Modified event insertion to return boolean indicating success vs. duplicate
- Removed redundant duplicate check in non-replaceable event path

### Data Access
- New DAO methods:
  - `getEventsOnly()`: Returns EventEntity without @Relation tag loading (no N+1 queries)
  - `getTagsForEvents()`: Batch-loads tags for multiple events in single query
  - `getEventJsonForIds()`: Batch-loads cached JSON for multiple events
- Changed EventSubscription from LruCache to ConcurrentHashMap for unbounded subscription tracking

## Notable Implementation Details
- Pre-computed UTF-8 byte constants (`J_CACHED_PREFIX`, `J_CACHED_SEP`, etc.) for zero-allocation JSON assembly
- Custom `ByteWriter` class handles UTF-8 encoding with proper escape sequences and surrogate pair support
- Semaphore sized to `Runtime.getRuntime().availableProcessors().coerceIn(2, 4)` to balance concurrency with connection pool limits
- Expiration check uses cached `expiresAt` column first, falls back to tag scan only for legacy events

https://claude.ai/code/session_01LC9GQBSKzGbAAazKyBWPhC