### PR TITLE
Convert remoteAddress from function to property with error handling

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/server/Connection.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Connection.kt
@@ -54,7 +54,12 @@ class Connection(
     }
     val name = "user${lastId.getAndIncrement()}"
 
-    fun remoteAddress(): String = "${session.call.request.local.remoteHost} ${session.call.request.headers["User-Agent"]}"
+    val remoteAddress: String = try {
+        "${session.call.request.local.remoteHost} ${session.call.request.headers["User-Agent"]}"
+    } catch (e: Exception) {
+        Log.w(Citrine.TAG, "Could not resolve remote address", e)
+        "unknown"
+    }
 
     fun finalize() {
         timer.cancel()
@@ -66,7 +71,7 @@ class Connection(
             session.outgoing.trySend(Frame.Text(data)).onClosed {
                 val connection = EventSubscription.getConnection(session)
                 connection?.let {
-                    Log.d(Citrine.TAG, "Session is closed for connection ${connection.name} ${connection.remoteAddress()}")
+                    Log.d(Citrine.TAG, "Session is closed for connection ${connection.name} ${connection.remoteAddress}")
                     Citrine.instance.applicationScope.launch {
                         CustomWebSocketService.server?.removeConnection(connection)
                     }

--- a/app/src/main/java/com/greenart7c3/citrine/ui/HomeScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/HomeScreen.kt
@@ -457,7 +457,7 @@ fun HomeScreen(
                                     }
                                 }
                                 items(connectionFlow!!.value) {
-                                    Text("${it.name} - ${it.remoteAddress()} - ${it.since.formatLongToCustomDateTimeWithSeconds()}")
+                                    Text("${it.name} - ${it.remoteAddress} - ${it.since.formatLongToCustomDateTimeWithSeconds()}")
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
Refactored the `remoteAddress` member in the `Connection` class from a function to a computed property with added exception handling to improve robustness and code clarity.

## Key Changes
- Changed `remoteAddress()` function to `remoteAddress` property in `Connection.kt`
- Added try-catch block to handle potential exceptions when resolving remote address
- Falls back to "unknown" string if remote address resolution fails, with warning log
- Updated all call sites to use property syntax instead of function call syntax:
  - `Connection.kt`: Log message in session close handler
  - `HomeScreen.kt`: Connection display in UI list

## Implementation Details
- The property now gracefully handles exceptions that may occur during `session.call.request.local.remoteHost` or header access
- Exceptions are logged at warning level with the tag `Citrine.TAG` for debugging purposes
- This change prevents potential crashes when remote address information is unavailable or inaccessible

https://claude.ai/code/session_01AsCFMKP4xAEmHrcP4K4BFB