### PR TITLE
Refactor EventRepository: Extract regex and factory to constants

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -13,6 +13,9 @@ import com.vitorpamplona.quartz.nip40Expiration.isExpired
 import kotlin.collections.isNotEmpty
 import kotlin.collections.joinToString
 
+private val TAG_KEY_REGEX = Regex("^[a-zA-Z0-9]+$")
+private val JACKSON_NODE_FACTORY = JacksonMapper.mapper.nodeFactory
+
 object EventRepository {
     fun createQuery(
         filter: EventFilter,
@@ -74,7 +77,7 @@ object EventRepository {
 
         // --- Add each tag as an AND EXISTS in WHERE ---
         filter.tags.forEach { tag ->
-            val safeTagKey = tag.key.takeIf { it.matches(Regex("^[a-zA-Z0-9]+$")) }
+            val safeTagKey = tag.key.takeIf { it.matches(TAG_KEY_REGEX) }
                 ?: throw IllegalArgumentException("Invalid tag key: ${tag.key}")
 
             val existsClause = StringBuilder()
@@ -183,25 +186,21 @@ object EventRepository {
     }
 }
 
-fun Event.toJsonObject(): JsonNode {
-    val factory = JacksonMapper.mapper.nodeFactory
-
-    return factory.objectNode().apply {
-        put("id", id)
-        put("pubkey", pubKey)
-        put("created_at", createdAt)
-        put("kind", kind)
-        replace(
-            "tags",
-            factory.arrayNode(tags.size).apply {
-                tags.forEach { tag ->
-                    add(
-                        factory.arrayNode(tag.size).apply { tag.forEach { add(it) } },
-                    )
-                }
-            },
-        )
-        put("content", content)
-        put("sig", sig)
-    }
+fun Event.toJsonObject(): JsonNode = JACKSON_NODE_FACTORY.objectNode().apply {
+    put("id", id)
+    put("pubkey", pubKey)
+    put("created_at", createdAt)
+    put("kind", kind)
+    replace(
+        "tags",
+        JACKSON_NODE_FACTORY.arrayNode(tags.size).apply {
+            tags.forEach { tag ->
+                add(
+                    JACKSON_NODE_FACTORY.arrayNode(tag.size).apply { tag.forEach { add(it) } },
+                )
+            }
+        },
+    )
+    put("content", content)
+    put("sig", sig)
 }


### PR DESCRIPTION
## Summary
This PR refactors the EventRepository to improve code maintainability and performance by extracting repeated objects into module-level constants and simplifying the `toJsonObject()` function.

## Key Changes
- Extracted `TAG_KEY_REGEX` as a private module-level constant to avoid recreating the regex pattern on every tag validation
- Extracted `JACKSON_NODE_FACTORY` as a private module-level constant to reuse the Jackson node factory instance
- Refactored `Event.toJsonObject()` function to use the extracted factory constant and converted it to an expression body for improved readability
- Removed local variable assignment in `toJsonObject()` in favor of direct constant usage

## Implementation Details
- The regex pattern for tag key validation (`^[a-zA-Z0-9]+$`) is now compiled once at module initialization rather than on each filter tag processing
- The Jackson node factory is now obtained once and reused across all JSON object creation calls, reducing object allocation overhead
- The `toJsonObject()` function maintains identical behavior while being more concise and efficient

https://claude.ai/code/session_01HYdtxr8zHmtK22JcHyEUbt