### PR TITLE
Background sync: WorkManager worker, scheduler, settings and UI for relay-aggregated downloads

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/Citrine.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/Citrine.kt
@@ -13,6 +13,7 @@ import com.greenart7c3.citrine.okhttp.HttpClientManager
 import com.greenart7c3.citrine.okhttp.OkHttpWebSocket
 import com.greenart7c3.citrine.server.OlderThan
 import com.greenart7c3.citrine.server.Settings
+import com.greenart7c3.citrine.service.BackgroundSyncScheduler
 import com.greenart7c3.citrine.service.LocalPreferences
 import com.greenart7c3.citrine.service.PokeyReceiver
 import com.greenart7c3.citrine.service.WebSocketServerService
@@ -95,6 +96,7 @@ class Citrine : Application() {
         client.connect()
 
         LocalPreferences.loadSettingsFromEncryptedStorage(this)
+        BackgroundSyncScheduler.reschedule(this)
         if (Settings.listenToPokeyBroadcasts) {
             registerPokeyReceiver()
         }

--- a/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
@@ -29,6 +29,11 @@ object Settings {
     var useProxy = false
     var proxyPort = 9050
     var webClients = mutableMapOf<String, String>()
+    var useRelayAggregatorForDownloads: Boolean = true
+    var backgroundSyncEnabled: Boolean = false
+    var backgroundSyncWifiOnly: Boolean = true
+    var backgroundSyncIntervalHours: Int = 6
+    var backgroundSyncPubkey: String = ""
 
     fun defaultValues() {
         allowedKinds = emptySet()
@@ -55,6 +60,11 @@ object Settings {
         useProxy = false
         proxyPort = 9050
         webClients = mutableMapOf()
+        useRelayAggregatorForDownloads = true
+        backgroundSyncEnabled = false
+        backgroundSyncWifiOnly = true
+        backgroundSyncIntervalHours = 6
+        backgroundSyncPubkey = ""
     }
 
     fun webClientFromJson(json: String): MutableMap<String, String> = JacksonMapper.mapper.readValue<MutableMap<String, String>>(json)

--- a/app/src/main/java/com/greenart7c3/citrine/service/BackgroundSyncScheduler.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/BackgroundSyncScheduler.kt
@@ -1,0 +1,49 @@
+package com.greenart7c3.citrine.service
+
+import android.content.Context
+import android.util.Log
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import com.greenart7c3.citrine.Citrine
+import com.greenart7c3.citrine.server.Settings
+import java.util.concurrent.TimeUnit
+
+object BackgroundSyncScheduler {
+    private const val UNIQUE_WORK_NAME = "citrine-background-sync"
+
+    fun reschedule(context: Context) {
+        val workManager = WorkManager.getInstance(context)
+        if (!Settings.backgroundSyncEnabled || Settings.backgroundSyncPubkey.isBlank()) {
+            Log.d(Citrine.TAG, "BackgroundSyncScheduler: Cancelling background sync")
+            workManager.cancelUniqueWork(UNIQUE_WORK_NAME)
+            return
+        }
+
+        val constraints =
+            Constraints.Builder()
+                .setRequiredNetworkType(if (Settings.backgroundSyncWifiOnly) NetworkType.UNMETERED else NetworkType.CONNECTED)
+                .setRequiresBatteryNotLow(true)
+                .build()
+
+        val request =
+            PeriodicWorkRequestBuilder<EventSyncWorker>(
+                Settings.backgroundSyncIntervalHours.toLong().coerceIn(1, 24),
+                TimeUnit.HOURS,
+            )
+                .setConstraints(constraints)
+                .build()
+
+        Log.d(
+            Citrine.TAG,
+            "BackgroundSyncScheduler: Scheduling sync every ${Settings.backgroundSyncIntervalHours}h, wifiOnly=${Settings.backgroundSyncWifiOnly}",
+        )
+        workManager.enqueueUniquePeriodicWork(
+            UNIQUE_WORK_NAME,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request,
+        )
+    }
+}

--- a/app/src/main/java/com/greenart7c3/citrine/service/EventDownloader.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/EventDownloader.kt
@@ -92,18 +92,7 @@ object EventDownloader {
         signer: NostrSigner,
     ): AdvertisedRelayListEvent? {
         var result: AdvertisedRelayListEvent? = null
-        val relays = listOf(
-            NormalizedRelayUrl(
-                url = "wss://purplepag.es",
-            ),
-            NormalizedRelayUrl(
-                url = "wss://relay.nostr.band",
-            ),
-        )
-        val finishedRelays = mutableMapOf<String, Boolean>()
-        relays.forEach {
-            finishedRelays[it.url] = false
-        }
+        val relays = relayAggregators()
 
         val subId = newSubId()
         val filters = listOf(
@@ -134,18 +123,7 @@ object EventDownloader {
         signer: NostrSigner,
     ): ContactListEvent? {
         var result: ContactListEvent? = null
-        val relays = listOf(
-            NormalizedRelayUrl(
-                url = "wss://purplepag.es",
-            ),
-            NormalizedRelayUrl(
-                url = "wss://relay.nostr.band",
-            ),
-        )
-        val finishedRelays = mutableMapOf<String, Boolean>()
-        relays.forEach {
-            finishedRelays[it.url] = false
-        }
+        val relays = relayAggregators()
         val subId = newSubId()
 
         val filters = listOf(
@@ -171,6 +149,11 @@ object EventDownloader {
         Citrine.instance.client.unsubscribe(subId)
         return result
     }
+
+    private fun relayAggregators(): List<NormalizedRelayUrl> = listOf(
+        NormalizedRelayUrl(url = "wss://purplepag.es"),
+        NormalizedRelayUrl(url = "wss://relay.nostr.band"),
+    )
 
     suspend fun fetchEvents(
         signer: NostrSigner,
@@ -207,6 +190,27 @@ object EventDownloader {
             Log.e(Citrine.TAG, e.message ?: "", e)
             setProgress("Failed to load events")
         }
+    }
+
+    suspend fun resolveDownloadRelays(
+        signer: NostrSigner,
+        useRelayAggregators: Boolean,
+    ): List<NormalizedRelayUrl> {
+        if (!useRelayAggregators) return emptyList()
+
+        val relays = mutableListOf<NormalizedRelayUrl>()
+        fetchContactList(signer)?.relays()?.forEach { relay ->
+            if (!relays.any { current -> current.url == relay.key.url }) {
+                relays.add(relay.key)
+            }
+        }
+        fetchAdvertisedRelayList(signer)?.relays()?.forEach { relay ->
+            if (!relays.any { current -> current.url == relay.relayUrl.url }) {
+                relays.add(relay.relayUrl)
+            }
+        }
+
+        return relays
     }
 
     fun setProgress(message: String) {

--- a/app/src/main/java/com/greenart7c3/citrine/service/EventSyncWorker.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/EventSyncWorker.kt
@@ -1,0 +1,48 @@
+package com.greenart7c3.citrine.service
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.greenart7c3.citrine.Citrine
+import com.greenart7c3.citrine.server.Settings
+import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
+import com.vitorpamplona.quartz.utils.Hex
+import kotlin.coroutines.cancellation.CancellationException
+
+class EventSyncWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        try {
+            val pubkey = Settings.backgroundSyncPubkey
+            if (pubkey.isBlank()) {
+                Log.d(Citrine.TAG, "EventSyncWorker: No background sync pubkey configured, skipping")
+                return Result.success()
+            }
+
+            val signer = NostrSignerInternal(KeyPair(pubKey = Hex.decode(pubkey)))
+            val relays = EventDownloader.resolveDownloadRelays(signer, Settings.useRelayAggregatorForDownloads)
+            if (relays.isEmpty()) {
+                Log.d(Citrine.TAG, "EventSyncWorker: No relays resolved for background sync")
+                return Result.success()
+            }
+
+            Log.d(Citrine.TAG, "EventSyncWorker: Starting background pull from ${relays.size} relays")
+            EventDownloader.fetchEvents(
+                signer = signer,
+                relays = relays,
+                downloadTaggedEvents = true,
+            )
+            Log.d(Citrine.TAG, "EventSyncWorker: Background pull complete")
+            return Result.success()
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Log.e(Citrine.TAG, "EventSyncWorker: Background pull failed", e)
+            return Result.retry()
+        }
+    }
+}

--- a/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
@@ -33,6 +33,11 @@ object PrefKeys {
     const val USE_PROXY = "use_proxy"
 
     const val WEB_CLIENTS = "web_clients"
+    const val USE_RELAY_AGGREGATOR_FOR_DOWNLOADS = "use_relay_aggregator_for_downloads"
+    const val BACKGROUND_SYNC_ENABLED = "background_sync_enabled"
+    const val BACKGROUND_SYNC_WIFI_ONLY = "background_sync_wifi_only"
+    const val BACKGROUND_SYNC_INTERVAL_HOURS = "background_sync_interval_hours"
+    const val BACKGROUND_SYNC_PUBKEY = "background_sync_pubkey"
 }
 
 object LocalPreferences {
@@ -77,6 +82,11 @@ object LocalPreferences {
                 } else {
                     remove(PrefKeys.WEB_CLIENTS)
                 }
+                putBoolean(PrefKeys.USE_RELAY_AGGREGATOR_FOR_DOWNLOADS, settings.useRelayAggregatorForDownloads)
+                putBoolean(PrefKeys.BACKGROUND_SYNC_ENABLED, settings.backgroundSyncEnabled)
+                putBoolean(PrefKeys.BACKGROUND_SYNC_WIFI_ONLY, settings.backgroundSyncWifiOnly)
+                putInt(PrefKeys.BACKGROUND_SYNC_INTERVAL_HOURS, settings.backgroundSyncIntervalHours)
+                putString(PrefKeys.BACKGROUND_SYNC_PUBKEY, settings.backgroundSyncPubkey)
 
                 HttpClientManager.setDefaultProxyOnPort(settings.proxyPort)
             }
@@ -111,6 +121,11 @@ object LocalPreferences {
         prefs.getString(PrefKeys.WEB_CLIENTS, null)?.let {
             Settings.webClients = Settings.webClientFromJson(it)
         }
+        Settings.useRelayAggregatorForDownloads = prefs.getBoolean(PrefKeys.USE_RELAY_AGGREGATOR_FOR_DOWNLOADS, true)
+        Settings.backgroundSyncEnabled = prefs.getBoolean(PrefKeys.BACKGROUND_SYNC_ENABLED, false)
+        Settings.backgroundSyncWifiOnly = prefs.getBoolean(PrefKeys.BACKGROUND_SYNC_WIFI_ONLY, true)
+        Settings.backgroundSyncIntervalHours = prefs.getInt(PrefKeys.BACKGROUND_SYNC_INTERVAL_HOURS, 6).coerceIn(1, 24)
+        Settings.backgroundSyncPubkey = prefs.getString(PrefKeys.BACKGROUND_SYNC_PUBKEY, "") ?: ""
 
         HttpClientManager.setDefaultProxyOnPort(Settings.proxyPort)
     }

--- a/app/src/main/java/com/greenart7c3/citrine/ui/DownloadYourEventsUserScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/DownloadYourEventsUserScreen.kt
@@ -59,7 +59,10 @@ import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.R
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.toEvent
+import com.greenart7c3.citrine.server.Settings
+import com.greenart7c3.citrine.service.BackgroundSyncScheduler
 import com.greenart7c3.citrine.service.EventDownloader
+import com.greenart7c3.citrine.service.LocalPreferences
 import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
 import com.vitorpamplona.quartz.nip01Core.relay.client.auth.RelayAuthenticator
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
@@ -244,6 +247,7 @@ fun DownloadYourEventsUserScreen(
     var npub by remember { mutableStateOf(TextFieldValue()) }
     var signer by remember { mutableStateOf<NostrSigner?>(null) }
     var downloadTaggedEvents by remember { mutableStateOf(true) }
+    var useRelayAggregatorForDownloads by remember { mutableStateOf(Settings.useRelayAggregatorForDownloads) }
 
     val launcherLogin = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult(),
@@ -278,6 +282,9 @@ fun DownloadYourEventsUserScreen(
                         )
 
                         npub = TextFieldValue(localNpub)
+                        Settings.backgroundSyncPubkey = returnedKey
+                        LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                        BackgroundSyncScheduler.reschedule(context)
                     } catch (e: Exception) {
                         Log.d(Citrine.TAG, e.message ?: "", e)
                     }
@@ -347,6 +354,26 @@ fun DownloadYourEventsUserScreen(
                 },
             )
             Text(stringResource(R.string.download_tagged_events))
+        }
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .clickable {
+                    useRelayAggregatorForDownloads = !useRelayAggregatorForDownloads
+                    Settings.useRelayAggregatorForDownloads = useRelayAggregatorForDownloads
+                    LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Checkbox(
+                checked = useRelayAggregatorForDownloads,
+                onCheckedChange = {
+                    useRelayAggregatorForDownloads = it
+                    Settings.useRelayAggregatorForDownloads = it
+                    LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                },
+            )
+            Text(stringResource(R.string.use_relay_aggregator_for_downloads))
         }
         ElevatedButton(
             content = {
@@ -432,8 +459,36 @@ fun DownloadYourEventsUserScreen(
                     ).show()
                     return@ElevatedButton
                 }
-
-                shouldShowDialog = true
+                Settings.backgroundSyncPubkey = signer!!.pubKey
+                LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                BackgroundSyncScheduler.reschedule(context)
+                if (useRelayAggregatorForDownloads) {
+                    Citrine.isImportingEvents = true
+                    Citrine.instance.cancelJob()
+                    Citrine.job = Citrine.instance.applicationScope.launch {
+                        val relays = EventDownloader.resolveDownloadRelays(signer!!, true)
+                        if (relays.isEmpty()) {
+                            scope.launch(Dispatchers.Main) {
+                                Toast.makeText(
+                                    context,
+                                    context.getString(R.string.no_relays_found),
+                                    Toast.LENGTH_SHORT,
+                                ).show()
+                            }
+                            shouldShowDialog = true
+                            return@launch
+                        }
+                        EventDownloader.setProgress("Connecting to ${relays.size} relays")
+                        EventDownloader.fetchEvents(
+                            signer = signer!!,
+                            relays = relays,
+                            downloadTaggedEvents = downloadTaggedEvents,
+                        )
+                    }
+                    navController.navigateUp()
+                } else {
+                    shouldShowDialog = true
+                }
             },
         )
     }

--- a/app/src/main/java/com/greenart7c3/citrine/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/SettingsScreen.kt
@@ -50,6 +50,7 @@ import com.greenart7c3.citrine.R
 import com.greenart7c3.citrine.server.OlderThan
 import com.greenart7c3.citrine.server.OlderThanType
 import com.greenart7c3.citrine.server.Settings
+import com.greenart7c3.citrine.service.BackgroundSyncScheduler
 import com.greenart7c3.citrine.service.LocalPreferences
 import com.greenart7c3.citrine.ui.components.PubkeyInputRow
 import com.greenart7c3.citrine.ui.components.PubkeyListItem
@@ -100,6 +101,11 @@ fun SettingsScreen(
         var useProxy by remember { mutableStateOf(Settings.useProxy) }
         var proxyPort by remember { mutableStateOf(TextFieldValue(Settings.proxyPort.toString())) }
         var autoBackup by remember { mutableStateOf(Settings.autoBackup) }
+        var useRelayAggregatorForDownloads by remember { mutableStateOf(Settings.useRelayAggregatorForDownloads) }
+        var backgroundSyncEnabled by remember { mutableStateOf(Settings.backgroundSyncEnabled) }
+        var backgroundSyncWifiOnly by remember { mutableStateOf(Settings.backgroundSyncWifiOnly) }
+        var backgroundSyncIntervalHours by remember { mutableStateOf(TextFieldValue(Settings.backgroundSyncIntervalHours.toString())) }
+        var backgroundSyncPubkey by remember { mutableStateOf(TextFieldValue(Settings.backgroundSyncPubkey)) }
 
         var signedBy by remember { mutableStateOf(TextFieldValue("")) }
         var referredBy by remember { mutableStateOf(TextFieldValue("")) }
@@ -252,7 +258,13 @@ fun SettingsScreen(
                                 allowedTaggedPubKeys = Settings.allowedTaggedPubKeys
                                 allowedKinds = Settings.allowedKinds
                                 neverDeleteFrom = Settings.neverDeleteFrom
+                                useRelayAggregatorForDownloads = Settings.useRelayAggregatorForDownloads
+                                backgroundSyncEnabled = Settings.backgroundSyncEnabled
+                                backgroundSyncWifiOnly = Settings.backgroundSyncWifiOnly
+                                backgroundSyncIntervalHours = TextFieldValue(Settings.backgroundSyncIntervalHours.toString())
+                                backgroundSyncPubkey = TextFieldValue(Settings.backgroundSyncPubkey)
                                 LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                                BackgroundSyncScheduler.reschedule(context)
                                 onApplyChanges()
                                 delay(1500)
                                 isLoading = false
@@ -473,6 +485,81 @@ fun SettingsScreen(
             // ── Others ─────────────────────────────────────────────────────────
             stickyHeader {
                 SectionHeader(stringResource(R.string.others))
+            }
+            item {
+                SwitchSettingRow(
+                    title = stringResource(R.string.use_relay_aggregator_for_downloads),
+                    description = stringResource(R.string.use_relay_aggregator_for_downloads_description),
+                    checked = useRelayAggregatorForDownloads,
+                    onCheckedChange = {
+                        useRelayAggregatorForDownloads = it
+                        Settings.useRelayAggregatorForDownloads = it
+                        LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                    },
+                )
+            }
+            item {
+                SwitchSettingRow(
+                    title = stringResource(R.string.background_sync_enabled),
+                    description = stringResource(R.string.background_sync_enabled_description),
+                    checked = backgroundSyncEnabled,
+                    onCheckedChange = {
+                        backgroundSyncEnabled = it
+                        Settings.backgroundSyncEnabled = it
+                        LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                        BackgroundSyncScheduler.reschedule(context)
+                    },
+                )
+            }
+            if (backgroundSyncEnabled) {
+                item {
+                    OutlinedTextField(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        value = backgroundSyncPubkey,
+                        label = { Text(stringResource(R.string.background_sync_pubkey)) },
+                        onValueChange = {
+                            backgroundSyncPubkey = it
+                            Settings.backgroundSyncPubkey = it.text.toNostrKey() ?: it.text
+                            LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                            BackgroundSyncScheduler.reschedule(context)
+                        },
+                        singleLine = true,
+                    )
+                }
+                item {
+                    OutlinedTextField(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        value = backgroundSyncIntervalHours,
+                        label = { Text(stringResource(R.string.background_sync_interval_hours)) },
+                        onValueChange = {
+                            backgroundSyncIntervalHours = it
+                            val interval = it.text.toIntOrNull()
+                            if (interval == null || interval < 1) return@OutlinedTextField
+                            Settings.backgroundSyncIntervalHours = interval.coerceAtMost(24)
+                            LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                            BackgroundSyncScheduler.reschedule(context)
+                        },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        singleLine = true,
+                    )
+                }
+                item {
+                    SwitchSettingRow(
+                        title = stringResource(R.string.background_sync_wifi_only),
+                        description = stringResource(R.string.background_sync_wifi_only_description),
+                        checked = backgroundSyncWifiOnly,
+                        onCheckedChange = {
+                            backgroundSyncWifiOnly = it
+                            Settings.backgroundSyncWifiOnly = it
+                            LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                            BackgroundSyncScheduler.reschedule(context)
+                        },
+                    )
+                }
             }
             item {
                 SwitchSettingRow(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,14 @@
     <string name="allow_all_pubkeys_hint">Empty list allows events from all pubkeys</string>
     <string name="allow_all_tagged_pubkeys_hint">Empty list allows events referencing any pubkey</string>
     <string name="allow_all_kinds_hint">Empty list allows all event kinds</string>
+    <string name="use_relay_aggregator_for_downloads">Use relay aggregators for downloads</string>
+    <string name="use_relay_aggregator_for_downloads_description">Automatically discover relays from aggregator relays before downloading</string>
+    <string name="background_sync_enabled">Background sync</string>
+    <string name="background_sync_enabled_description">Periodically pull your events using WorkManager</string>
+    <string name="background_sync_pubkey">Background sync account (npub/hex)</string>
+    <string name="background_sync_interval_hours">Sync interval (hours)</string>
+    <string name="background_sync_wifi_only">Wi‑Fi only sync</string>
+    <string name="background_sync_wifi_only_description">Run background sync only on unmetered networks</string>
     <string name="start_on_boot_description">Automatically start the relay when the device boots</string>
     <string name="enable_disable_auth_description">Require NIP-42 authentication for private event kinds</string>
     <string name="listen_to_pokey_broadcasts_description">Receive events broadcast by the Pokey app</string>


### PR DESCRIPTION
### Motivation
- Add periodic background pull of a user account's events and allow discovering download relays via aggregator relays. 
- Expose configuration for background sync and relay-aggregator behavior through persisted settings and the settings UI.
- Ensure scheduling is applied when settings change or on app startup so background sync follows user preferences.

### Description
- Added `EventSyncWorker` implementing `CoroutineWorker` to perform background pulls using `EventDownloader.fetchEvents` and relay resolution via `EventDownloader.resolveDownloadRelays`.
- Added `BackgroundSyncScheduler` to schedule/cancel a unique periodic `WorkManager` job and wired `BackgroundSyncScheduler.reschedule` into `Citrine.onCreate` and settings/UI flows.
- Extended `Settings` with new fields: `useRelayAggregatorForDownloads`, `backgroundSyncEnabled`, `backgroundSyncWifiOnly`, `backgroundSyncIntervalHours`, and `backgroundSyncPubkey` and persisted them via `LocalPreferences` with new keys.
- Updated `EventDownloader` to extract aggregator relays (`relayAggregators`) and to provide `resolveDownloadRelays` which queries contact lists and advertised relay lists for discovered relays.
- Updated UI: `SettingsScreen` gets controls for enabling background sync, interval, Wi‑Fi-only, and relay-aggregator toggle, plus strings; `DownloadYourEventsUserScreen` persists background sync pubkey, toggles aggregator use, and reschedules background sync and immediate downloads when appropriate.

### Testing
- Built the app with `./gradlew assembleDebug` to validate compilation and resource changes, which completed successfully.
- No automated unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8aa5ef820832d8ec5474262aa87f5)