### PR TITLE
Fix EventFilter tag matching logic

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/server/EventFilter.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventFilter.kt
@@ -36,7 +36,7 @@ data class EventFilter(
             return false
         }
 
-        if (tags.isNotEmpty() && tags.none { testTag(it, event) }) {
+        if (tags.isNotEmpty() && !tags.all { testTag(it, event) }) {
             return false
         }
 


### PR DESCRIPTION
## Summary
Fixed the tag matching logic in EventFilter to correctly validate that all tags match the event, rather than incorrectly rejecting events when any tag matches.

## Key Changes
- Changed tag validation from `tags.none { testTag(it, event) }` to `!tags.all { testTag(it, event) }`
- This ensures the filter returns false only when NOT all tags match, rather than when no tags match
- The logical equivalence is: `!all(condition)` correctly replaces `none(condition)` for this use case

## Implementation Details
The original logic would reject an event if none of its tags passed the test. The corrected logic now properly rejects an event only if not all of its tags pass the test, which aligns with the expected filter behavior where all specified tags should match for an event to pass the filter.

https://claude.ai/code/session_011VV7JUFCP3ujUA681Sdi2V