### PR TITLE
Fix race condition in relay subscription handling

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -11,6 +11,7 @@ import com.greenart7c3.citrine.database.EventDao
 import com.greenart7c3.citrine.database.PubkeyTimestamp
 import com.greenart7c3.citrine.database.toEvent
 import com.greenart7c3.citrine.server.Settings
+import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.fetchFirst
 import com.vitorpamplona.quartz.nip01Core.relay.client.listeners.RelayConnectionListener
 import com.vitorpamplona.quartz.nip01Core.relay.client.single.IRelayClient
@@ -621,6 +622,30 @@ object RelayAggregator {
         }
     }
 
+    /**
+     * Validate that [ev] matches the filter we asked [relayUrl] for under [subId]. Misbehaving or
+     * lax relays sometimes ship events outside of the REQ filter (wrong author, wrong kind, older
+     * than `since`, missing the required tag). Drop those before they hit the database.
+     */
+    private fun matchesRequestedFilter(relayUrl: NormalizedRelayUrl, subId: String, ev: Event): Boolean {
+        val entry = activeRelaySubs[relayUrl]?.firstOrNull { it.subId == subId } ?: return false
+
+        val kinds = Settings.relayAggregatorKinds
+        if (kinds.isNotEmpty() && ev.kind !in kinds) return false
+
+        if (ev.createdAt < entry.since) return false
+
+        if (entry.authors.isNotEmpty()) {
+            if (ev.pubKey !in entry.authors) return false
+        } else if (subId == taggedSubId) {
+            val aggPubkey = Settings.aggregatorPubkey
+            if (aggPubkey.isBlank()) return false
+            val tagged = ev.tags.any { it.size > 1 && it[0] == "p" && it[1] == aggPubkey }
+            if (!tagged) return false
+        }
+        return true
+    }
+
     private fun sendSubscribe(relay: NormalizedRelayUrl, subId: String, filters: List<Filter>) {
         runCatching {
             Citrine.instance.client.subscribe(subId, mapOf(relay to filters))
@@ -867,6 +892,10 @@ object RelayAggregator {
                     )
                 }
                 refreshStatusCounters()
+                if (!matchesRequestedFilter(relay.url, msg.subId, ev)) {
+                    Log.d(TAG, "Dropping event ${ev.id} from ${relay.url.url} sub ${msg.subId}: does not match requested filter")
+                    return
+                }
                 val s = scope ?: return
                 s.launch {
                     try {

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -493,6 +493,7 @@ object RelayAggregator {
                 }
                 val existing = activeRelaySubs[relay] ?: emptyList()
                 val entries = mutableListOf<ChunkSubscription>()
+                val pendingSubscribes = mutableListOf<Pair<String, List<Filter>>>()
                 chunks.forEachIndexed { idx, chunk ->
                     val reused = existing.getOrNull(idx)?.subId
                     val subId = reused ?: newSubId()
@@ -510,8 +511,6 @@ object RelayAggregator {
                             since = chunkSince,
                         ),
                     )
-                    sendSubscribe(relay, subId, filters)
-                    trackedSubIds.add(subId)
                     entries.add(
                         ChunkSubscription(
                             subId = subId,
@@ -519,7 +518,16 @@ object RelayAggregator {
                             since = chunkSince,
                         ),
                     )
+                    trackedSubIds.add(subId)
+                    pendingSubscribes.add(subId to filters)
                 }
+                // Publish the new entries to activeRelaySubs BEFORE issuing any REQ for this
+                // relay. Otherwise the listener races: an event response arrives between
+                // sendSubscribe() and the final swap below, lookup misses, and the event is
+                // dropped as "unknown relay (no active subs)".
+                newActiveSubs[relay] = entries
+                activeRelaySubs[relay] = entries.toMutableList()
+                pendingSubscribes.forEach { (subId, filters) -> sendSubscribe(relay, subId, filters) }
                 if (existing.size > chunks.size) {
                     for (i in chunks.size until existing.size) {
                         val oldId = existing[i].subId
@@ -528,7 +536,6 @@ object RelayAggregator {
                         closedExtraChunkSubs++
                     }
                 }
-                newActiveSubs[relay] = entries
             }
 
             var closedGoneRelaySubs = 0
@@ -577,9 +584,6 @@ object RelayAggregator {
                         "Tagged sub: $id to ${taggedSubRelays.size} relays " +
                             "(${readRelays.size} from inbox, ${FALLBACK_OUTBOX_RELAYS.size} fallback)",
                     )
-                    runCatching {
-                        Citrine.instance.client.subscribe(id, taggedSubRelays.associateWith { filters })
-                    }.onFailure { Log.e(TAG, "tagged subscribe failed", it) }
                     val taggedEntry = ChunkSubscription(
                         subId = id,
                         authors = emptySet(),
@@ -587,7 +591,17 @@ object RelayAggregator {
                     )
                     taggedSubRelays.forEach { relay ->
                         newActiveSubs.getOrPut(relay) { mutableListOf() }.add(taggedEntry)
+                        // Publish into live state BEFORE the subscribe call, same race fix as
+                        // the main-sub loop above.
+                        activeRelaySubs.compute(relay) { _, current ->
+                            val list = current?.let { ArrayList(it) } ?: ArrayList()
+                            list.add(taggedEntry)
+                            list
+                        }
                     }
+                    runCatching {
+                        Citrine.instance.client.subscribe(id, taggedSubRelays.associateWith { filters })
+                    }.onFailure { Log.e(TAG, "tagged subscribe failed", it) }
                 }
             } else {
                 taggedSubId?.let {
@@ -598,8 +612,15 @@ object RelayAggregator {
                 taggedSubId = null
             }
 
-            activeRelaySubs.clear()
-            activeRelaySubs.putAll(newActiveSubs)
+            // activeRelaySubs has been populated incrementally during the main-sub and
+            // tagged-sub passes (so the listener can resolve responses without racing the
+            // final swap). Just drop relays that vanished this refresh — their subIds were
+            // already unsubscribed in the closedGoneRelaySubs loop above.
+            val staleRelays = activeRelaySubs.keys.toSet() - newActiveSubs.keys
+            staleRelays.forEach { activeRelaySubs.remove(it) }
+            // Replace lists for relays that survived to make sure the in-memory state matches
+            // newActiveSubs exactly (e.g., picks up tagged-sub-only relays uniformly).
+            newActiveSubs.forEach { (relay, entries) -> activeRelaySubs[relay] = entries }
 
             val newSubscribedRelays = newActiveSubs.keys
             subscribedRelays.clear()

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -625,25 +625,33 @@ object RelayAggregator {
     /**
      * Validate that [ev] matches the filter we asked [relayUrl] for under [subId]. Misbehaving or
      * lax relays sometimes ship events outside of the REQ filter (wrong author, wrong kind, older
-     * than `since`, missing the required tag). Drop those before they hit the database.
+     * than `since`, missing the required tag). Returns null when it matches; otherwise a short
+     * human-readable reason for the caller to log.
      */
-    private fun matchesRequestedFilter(relayUrl: NormalizedRelayUrl, subId: String, ev: Event): Boolean {
-        val entry = activeRelaySubs[relayUrl]?.firstOrNull { it.subId == subId } ?: return false
+    private fun filterMismatchReason(relayUrl: NormalizedRelayUrl, subId: String, ev: Event): String? {
+        val entries = activeRelaySubs[relayUrl] ?: return "unknown relay (no active subs)"
+        val entry = entries.firstOrNull { it.subId == subId } ?: return "unknown subId"
 
         val kinds = Settings.relayAggregatorKinds
-        if (kinds.isNotEmpty() && ev.kind !in kinds) return false
+        if (kinds.isNotEmpty() && ev.kind !in kinds) {
+            return "kind ${ev.kind} not in requested kinds $kinds"
+        }
 
-        if (ev.createdAt < entry.since) return false
+        if (ev.createdAt < entry.since) {
+            return "createdAt ${ev.createdAt} < requested since ${entry.since}"
+        }
 
         if (entry.authors.isNotEmpty()) {
-            if (ev.pubKey !in entry.authors) return false
+            if (ev.pubKey !in entry.authors) {
+                return "pubkey ${ev.pubKey} not in requested authors (${entry.authors.size})"
+            }
         } else if (subId == taggedSubId) {
             val aggPubkey = Settings.aggregatorPubkey
-            if (aggPubkey.isBlank()) return false
+            if (aggPubkey.isBlank()) return "tagged sub active but aggregator pubkey is blank"
             val tagged = ev.tags.any { it.size > 1 && it[0] == "p" && it[1] == aggPubkey }
-            if (!tagged) return false
+            if (!tagged) return "missing required p-tag for $aggPubkey"
         }
-        return true
+        return null
     }
 
     private fun sendSubscribe(relay: NormalizedRelayUrl, subId: String, filters: List<Filter>) {
@@ -892,8 +900,9 @@ object RelayAggregator {
                     )
                 }
                 refreshStatusCounters()
-                if (!matchesRequestedFilter(relay.url, msg.subId, ev)) {
-                    Log.d(TAG, "Dropping event ${ev.id} from ${relay.url.url} sub ${msg.subId}: does not match requested filter")
+                val mismatchReason = filterMismatchReason(relay.url, msg.subId, ev)
+                if (mismatchReason != null) {
+                    Log.d(TAG, "Dropping event ${ev.id} (kind ${ev.kind}) from ${relay.url.url} sub ${msg.subId}: $mismatchReason")
                     return
                 }
                 val s = scope ?: return


### PR DESCRIPTION
## Summary
This PR fixes a critical race condition in the relay subscription system where incoming events could be dropped as "unknown relay (no active subs)" if they arrived between when a subscription was sent and when the subscription state was updated in memory.

## Key Changes

- **Reorder subscription state updates**: Populate `activeRelaySubs` BEFORE sending subscription requests to relays, ensuring the listener can resolve incoming events without racing the state update.

- **Add filter validation**: Introduce `filterMismatchReason()` method to validate that events from relays match the requested filters (kind, since timestamp, authors, required tags). This catches misbehaving relays that send events outside the requested parameters.

- **Improve state management**: 
  - For main subscriptions: build pending subscriptions in a list, update `activeRelaySubs`, then send all requests
  - For tagged subscriptions: update `activeRelaySubs` before calling `subscribe()`
  - Replace the final `clear()` + `putAll()` with incremental updates to avoid clearing state that was already populated

- **Add event filtering**: Drop events that fail filter validation with detailed logging about why they were rejected (wrong kind, too old, wrong author, missing required tag).

## Implementation Details

The core issue was that the listener thread could receive relay responses before the main thread finished updating `activeRelaySubs`, causing lookups to fail. By populating the state map before sending requests, responses can be properly matched to their subscriptions.

The new `filterMismatchReason()` method provides defense-in-depth against relay misbehavior, validating:
- Event kind matches requested kinds
- Event timestamp is not older than requested `since`
- Event author is in the requested author set (if specified)
- Event contains required p-tag for tagged subscriptions

https://claude.ai/code/session_01T9JQsCBTWHd81AHT49qGUm