### PR TITLE
fix: relieve UI thread pressure on the event-receive path

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/server/Connection.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Connection.kt
@@ -6,14 +6,16 @@ import com.greenart7c3.citrine.service.CustomWebSocketService
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import io.ktor.server.websocket.DefaultWebSocketServerSession
 import io.ktor.websocket.Frame
-import java.util.Timer
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.onClosed
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 class Connection(
@@ -25,28 +27,18 @@ class Connection(
     val sharedFlow = messageResponseFlow.asSharedFlow()
 
     val since = System.currentTimeMillis()
-    val timer = Timer()
-
-    init {
-        timer.schedule(
-            object : java.util.TimerTask() {
-                override fun run() {
-                    val hasTenMinutesPassed = System.currentTimeMillis() - since > 10 * 60 * 1000
-                    if (hasTenMinutesPassed) {
-                        if (!EventSubscription.containsConnection(this@Connection)) {
-                            Log.d(Citrine.TAG, "Closing session due to inactivity")
-                            finalize()
-                            Citrine.instance.applicationScope.launch {
-                                session.cancel()
-                                CustomWebSocketService.server?.removeConnection(this@Connection)
-                            }
-                        }
-                    }
-                }
-            },
-            0,
-            60000,
-        )
+    private val inactivityJob: Job = Citrine.instance.applicationScope.launch {
+        while (isActive) {
+            delay(60_000)
+            val hasTenMinutesPassed = System.currentTimeMillis() - since > 10 * 60 * 1000
+            if (hasTenMinutesPassed && !EventSubscription.containsConnection(this@Connection)) {
+                Log.d(Citrine.TAG, "Closing session due to inactivity")
+                finalize()
+                session.cancel()
+                CustomWebSocketService.server?.removeConnection(this@Connection)
+                break
+            }
+        }
     }
 
     companion object {
@@ -62,7 +54,7 @@ class Connection(
     }
 
     fun finalize() {
-        timer.cancel()
+        inactivityJob.cancel()
         EventSubscription.closeAll(name)
     }
 

--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -1183,9 +1183,7 @@ class CustomWebSocketServer(
                         for (message in incoming) {
                             if (message !is Frame.Text) continue
                             try {
-                                withContext(Dispatchers.IO) {
-                                    processNewRelayMessage(message.readText(), thisConnection)
-                                }
+                                processNewRelayMessage(message.readText(), thisConnection)
                             } catch (e: Exception) {
                                 if (e !is CancellationException) {
                                     Log.d(Citrine.TAG, "Error processing message: $e", e)

--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -1200,8 +1200,7 @@ class CustomWebSocketServer(
         Log.d(Citrine.TAG, "Removing ${connection.name}!")
         connection.session.cancel()
         connection.finalize()
-        connections.value.remove(connection)
-        connections.emit(connections.value)
+        connections.emit(connections.value.filterNot { it === connection })
     }
 }
 

--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -223,7 +223,9 @@ class CustomWebSocketServer(
     @OptIn(DelicateCoroutinesApi::class)
     private suspend fun processNewRelayMessage(newMessage: String, connection: Connection?) {
         try {
-            Log.d(Citrine.TAG, newMessage + " from ${connection?.session?.call?.request?.local?.remoteHost} ${connection?.session?.call?.request?.headers?.get("User-Agent")}")
+            if (Log.isLoggable(Citrine.TAG, Log.DEBUG)) {
+                Log.d(Citrine.TAG, newMessage + " from ${connection?.session?.call?.request?.local?.remoteHost} ${connection?.session?.call?.request?.headers?.get("User-Agent")}")
+            }
             val msgArray = JacksonMapper.mapper.readTree(newMessage)
             when (val type = msgArray.get(0).asText()) {
                 "COUNT" -> {
@@ -651,13 +653,24 @@ class CustomWebSocketServer(
         HistoryDatabase.getDatabase(Citrine.instance).eventDao().insertEventWithTags(event.toEventWithTags(), connection = connection)
     }
 
-    private fun isOffline(): Boolean {
-        val connectivityManager = Citrine.instance.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
-            ?: return true
+    @Volatile private var cachedIsOffline: Boolean = false
 
-        val network = connectivityManager.activeNetwork
-        val capabilities = connectivityManager.getNetworkCapabilities(network)
-        return capabilities == null || !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    @Volatile private var cachedIsOfflineAt: Long = 0L
+
+    private fun isOffline(): Boolean {
+        val now = System.currentTimeMillis()
+        if (now - cachedIsOfflineAt < 5_000L) return cachedIsOffline
+
+        val connectivityManager = Citrine.instance.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+        val offline = if (connectivityManager == null) {
+            true
+        } else {
+            val capabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+            capabilities == null || !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        }
+        cachedIsOffline = offline
+        cachedIsOfflineAt = now
+        return offline
     }
 
     private fun broadcastWithWorkManager(dbEvent: EventWithTags) {

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventSubscription.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventSubscription.kt
@@ -42,13 +42,18 @@ object EventSubscription {
     fun executeAll(dbEvent: EventWithTags, connection: Connection?) {
         Citrine.instance.applicationScope.launch(Dispatchers.IO) {
             val event = dbEvent.toEvent()
-            val eventJsonStr = ENVELOPE_MAPPER.writeValueAsString(event.toJsonObject())
+            var eventJsonStr: String? = null
             var sentEvent = false
             for (manager in subscriptions.snapshot().values) {
                 val sub = manager.subscription
-                if (sub.connection.session.outgoing.isClosedForSend) continue
+                if (sub.connection.session.outgoing.isClosedForSend) {
+                    // Drop closed subscriptions so future fanouts skip them entirely.
+                    close(sub.id)
+                    continue
+                }
                 if (sub.filters.any { it.test(event) }) {
-                    sub.connection.trySend("[\"EVENT\",${sub.escapedId},$eventJsonStr]")
+                    val json = eventJsonStr ?: ENVELOPE_MAPPER.writeValueAsString(event.toJsonObject()).also { eventJsonStr = it }
+                    sub.connection.trySend("[\"EVENT\",${sub.escapedId},$json]")
                     sentEvent = true
                 }
             }

--- a/app/src/main/java/com/greenart7c3/citrine/ui/HomeScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/HomeScreen.kt
@@ -71,6 +71,8 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.launch
 
 @Composable
@@ -408,7 +410,9 @@ fun HomeScreen(
                 }
 
                 if (Settings.relayAggregatorEnabled) {
-                    val aggregatorStatus = RelayAggregator.status.collectAsStateWithLifecycle()
+                    @OptIn(FlowPreview::class)
+                    val aggregatorStatus = remember { RelayAggregator.status.sample(2_000) }
+                        .collectAsStateWithLifecycle(initialValue = RelayAggregator.status.value)
                     AggregatorStatusCard(
                         status = aggregatorStatus.value,
                         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/greenart7c3/citrine/ui/LogcatViewModel.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/LogcatViewModel.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+private const val MAX_LOG_LINES = 500
+
 class LogcatViewModel : ViewModel() {
     private val _logMessages = MutableStateFlow<List<String>>(emptyList())
     val logMessages = _logMessages.asStateFlow()
@@ -35,12 +37,12 @@ class LogcatViewModel : ViewModel() {
                 val process = Runtime.getRuntime().exec("logcat --pid=$processId -s ${Citrine.TAG}:* -s CitrineContentProvider:*")
                 val reader = BufferedReader(InputStreamReader(process.inputStream))
 
-                var log = mutableListOf<String>()
+                val buffer = ArrayDeque<String>()
                 reader.useLines { lines ->
                     lines.forEach { logMessage ->
-                        // Update logs with the new log message added at the top (inverted order)
-                        log = (mutableListOf(logMessage) + log).toMutableList()
-                        _logMessages.value = log
+                        buffer.addFirst(logMessage)
+                        while (buffer.size > MAX_LOG_LINES) buffer.removeLast()
+                        _logMessages.value = buffer.toList()
                     }
                 }
             } catch (e: Exception) {

--- a/app/src/main/java/com/greenart7c3/citrine/ui/components/DatabaseInfo.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/components/DatabaseInfo.kt
@@ -45,7 +45,9 @@ import com.greenart7c3.citrine.R
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.EventDao
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -147,8 +149,10 @@ class DatabaseInfoViewModel(
     database: AppDatabase,
 ) : ViewModel() {
 
+    @OptIn(FlowPreview::class)
     val countByKind =
         database.eventDao().countByKind()
+            .sample(2_000)
             .stateIn(
                 viewModelScope,
                 SharingStarted.WhileSubscribed(5_000),


### PR DESCRIPTION
The relay UI froze under sustained inbound event traffic because every
EVENT triggered a full-table COUNT(*) GROUP BY (re-firing the HomeScreen
pie chart Flow), an unconditional Jackson serialization in the
subscription fanout, and a per-connection Timer thread that outlived its
WebSocket. Throttle the Flow to 2 s, defer JSON serialization until a
subscription matches, evict closed subscriptions during fanout, and
replace the Timer with a coroutine tied to applicationScope. Also emit a
fresh list instance from the connections StateFlow so disconnects
propagate to the UI, and cap the in-app log buffer at 500 lines.

https://claude.ai/code/session_01W66SBkZ96KRZgdqKqwyByB