### PR TITLE
Bypass allowlist checks for aggregator-fetched events

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -319,7 +319,7 @@ class CustomWebSocketServer(
         AuthRequiredForProtectedEvent,
     }
 
-    suspend fun verifyEvent(event: Event, connection: Connection?, shouldVerify: Boolean): VerificationResult {
+    suspend fun verifyEvent(event: Event, connection: Connection?, shouldVerify: Boolean, fromAggregator: Boolean = false): VerificationResult {
         if (!shouldVerify) {
             return VerificationResult.Valid
         }
@@ -334,17 +334,22 @@ class CustomWebSocketServer(
             return VerificationResult.KindNotAllowed
         }
 
-        if (Settings.allowedTaggedPubKeys.isNotEmpty() && event.taggedUsers().isNotEmpty() && event.taggedUsers().none { it.pubKey in Settings.allowedTaggedPubKeys }) {
-            if (Settings.allowedPubKeys.isEmpty() || (event.pubKey !in Settings.allowedPubKeys)) {
-                Log.d(Citrine.TAG, "tagged pubkey not allowed ${event.id}")
-                return VerificationResult.TaggedPubkeyNotAllowed
+        // Aggregator-fetched events bypass the author/tagged-pubkey allowlists
+        // because the aggregator already validated them against the user's
+        // requested subscription filter before handing them off here.
+        if (!fromAggregator) {
+            if (Settings.allowedTaggedPubKeys.isNotEmpty() && event.taggedUsers().isNotEmpty() && event.taggedUsers().none { it.pubKey in Settings.allowedTaggedPubKeys }) {
+                if (Settings.allowedPubKeys.isEmpty() || (event.pubKey !in Settings.allowedPubKeys)) {
+                    Log.d(Citrine.TAG, "tagged pubkey not allowed ${event.id}")
+                    return VerificationResult.TaggedPubkeyNotAllowed
+                }
             }
-        }
 
-        if (Settings.allowedPubKeys.isNotEmpty() && event.pubKey !in Settings.allowedPubKeys) {
-            if (Settings.allowedTaggedPubKeys.isEmpty() || event.taggedUsers().none { it.pubKey in Settings.allowedTaggedPubKeys }) {
-                Log.d(Citrine.TAG, "pubkey not allowed ${event.id}")
-                return VerificationResult.PubkeyNotAllowed
+            if (Settings.allowedPubKeys.isNotEmpty() && event.pubKey !in Settings.allowedPubKeys) {
+                if (Settings.allowedTaggedPubKeys.isEmpty() || event.taggedUsers().none { it.pubKey in Settings.allowedTaggedPubKeys }) {
+                    Log.d(Citrine.TAG, "pubkey not allowed ${event.id}")
+                    return VerificationResult.PubkeyNotAllowed
+                }
             }
         }
 
@@ -438,8 +443,8 @@ class CustomWebSocketServer(
         return VerificationResult.Valid
     }
 
-    suspend fun innerProcessEvent(event: Event, connection: Connection?, shouldVerify: Boolean = true): VerificationResult {
-        val result = verifyEvent(event, connection, shouldVerify)
+    suspend fun innerProcessEvent(event: Event, connection: Connection?, shouldVerify: Boolean = true, fromAggregator: Boolean = false): VerificationResult {
+        val result = verifyEvent(event, connection, shouldVerify, fromAggregator)
         when (result) {
             VerificationResult.AuthRequiredForProtectedEvent -> {
                 connection?.trySend(AuthResult.challenge(connection.authChallenge).toJson())

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -216,7 +216,7 @@ object RelayAggregator {
         newScope.launch {
             for (ev in newEventChannel) {
                 try {
-                    CustomWebSocketService.server?.innerProcessEvent(ev, null)
+                    CustomWebSocketService.server?.innerProcessEvent(ev, null, fromAggregator = true)
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
@@ -1004,18 +1004,18 @@ object RelayAggregator {
         )
         if (needsRelayList) {
             fetchSingleReplaceable(AdvertisedRelayListEvent.KIND, pubkey, INDEXER_RELAYS)?.let {
-                CustomWebSocketService.server?.innerProcessEvent(it, null)
+                CustomWebSocketService.server?.innerProcessEvent(it, null, fromAggregator = true)
             }
         }
         if (needsMetadata) {
             val metadataRelays = userWriteRelays(dao, pubkey) ?: INDEXER_RELAYS
             fetchSingleReplaceable(MetadataEvent.KIND, pubkey, metadataRelays)?.let {
-                CustomWebSocketService.server?.innerProcessEvent(it, null)
+                CustomWebSocketService.server?.innerProcessEvent(it, null, fromAggregator = true)
             }
         }
         if (needsContactList) {
             fetchSingleReplaceable(ContactListEvent.KIND, pubkey, INDEXER_RELAYS)?.let {
-                CustomWebSocketService.server?.innerProcessEvent(it, null)
+                CustomWebSocketService.server?.innerProcessEvent(it, null, fromAggregator = true)
             }
         }
     }
@@ -1059,7 +1059,7 @@ object RelayAggregator {
         } finally {
             runCatching { Citrine.instance.client.unsubscribe(subId) }
         }
-        fetched?.let { CustomWebSocketService.server?.innerProcessEvent(it, null) }
+        fetched?.let { CustomWebSocketService.server?.innerProcessEvent(it, null, fromAggregator = true) }
         // Prefer whichever copy is newest — a cache hit may still beat a slow/partial fetch.
         val fetchedContactList = fetched as? ContactListEvent
         return when {
@@ -1154,7 +1154,7 @@ object RelayAggregator {
 
         // Persist what we learned so future refreshes are a cache hit.
         results.values.forEach {
-            runCatching { CustomWebSocketService.server?.innerProcessEvent(it, null) }
+            runCatching { CustomWebSocketService.server?.innerProcessEvent(it, null, fromAggregator = true) }
         }
         return results
     }
@@ -1245,7 +1245,7 @@ object RelayAggregator {
         }
 
         results.values.forEach {
-            runCatching { CustomWebSocketService.server?.innerProcessEvent(it, null) }
+            runCatching { CustomWebSocketService.server?.innerProcessEvent(it, null, fromAggregator = true) }
         }
         return results
     }


### PR DESCRIPTION
## Summary
This PR adds a `fromAggregator` flag to event verification to bypass author and tagged-pubkey allowlist checks for events fetched by the RelayAggregator. This prevents duplicate validation since the aggregator already validates events against the user's subscription filters before passing them to the server.

## Key Changes
- Added `fromAggregator: Boolean = false` parameter to `verifyEvent()` and `innerProcessEvent()` methods in `CustomWebSocketServer`
- Wrapped author/tagged-pubkey allowlist validation logic in a `!fromAggregator` condition to skip these checks for aggregator-sourced events
- Updated all `RelayAggregator` calls to `innerProcessEvent()` to pass `fromAggregator = true`, including:
  - Relay list, metadata, and contact list fetches
  - Single replaceable event fetches
  - Batch event fetches from relays
  - Streaming event subscriptions

## Implementation Details
The allowlist bypass is safe because the RelayAggregator already validates fetched events against the user's requested subscription filters before handing them off to the server. This eliminates redundant validation while maintaining security for events from direct client connections (which still undergo full allowlist checks).

https://claude.ai/code/session_01XqALMLyah9RpmDY4xBhVLP