### PR TITLE
Add preserved kinds setting to prevent age-based deletion

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/Citrine.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/Citrine.kt
@@ -139,10 +139,17 @@ class Citrine : Application() {
                         if (until > 0) {
                             val duration = measureTime {
                                 Log.d(TAG, "Deleting old events (older than ${Settings.deleteEventsOlderThan})")
-                                if (Settings.neverDeleteFrom.isNotEmpty()) {
-                                    database.eventDao().deleteAll(until, Settings.neverDeleteFrom.toTypedArray())
-                                } else {
-                                    database.eventDao().deleteAll(until)
+                                val neverFrom = Settings.neverDeleteFrom
+                                val preserved = Settings.preservedKindsFromDeletion
+                                when {
+                                    neverFrom.isEmpty() && preserved.isEmpty() ->
+                                        database.eventDao().deleteAll(until)
+                                    neverFrom.isEmpty() ->
+                                        database.eventDao().deleteAll(until, preserved.toIntArray())
+                                    preserved.isEmpty() ->
+                                        database.eventDao().deleteAll(until, neverFrom.toTypedArray())
+                                    else ->
+                                        database.eventDao().deleteAll(until, neverFrom.toTypedArray(), preserved.toIntArray())
                                 }
                             }
                             Log.d(TAG, "Deleted old events in $duration")

--- a/app/src/main/java/com/greenart7c3/citrine/database/EventDao.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/EventDao.kt
@@ -267,6 +267,14 @@ interface EventDao {
     @Transaction
     suspend fun deleteAll(until: Long, pubKeys: Array<String>)
 
+    @Query("DELETE FROM EventEntity WHERE createdAt <= :until AND kind NOT IN (:kinds)")
+    @Transaction
+    suspend fun deleteAll(until: Long, kinds: IntArray)
+
+    @Query("DELETE FROM EventEntity WHERE createdAt <= :until AND pubkey NOT IN (:pubKeys) AND kind NOT IN (:kinds)")
+    @Transaction
+    suspend fun deleteAll(until: Long, pubKeys: Array<String>, kinds: IntArray)
+
     @Transaction
     suspend fun deleteEphemeralEvents(oneMinuteAgo: Long) {
         val ids = getEphemeralEvents(oneMinuteAgo)

--- a/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
@@ -13,6 +13,7 @@ object Settings {
     var host: String = "127.0.0.1"
     var port: Int = 4869
     var neverDeleteFrom: Set<String> = emptySet()
+    var preservedKindsFromDeletion: Set<Int> = setOf(0, 3, 10002)
     var name: String = "Citrine"
     var ownerPubkey: String = ""
     var contact: String = ""
@@ -54,6 +55,7 @@ object Settings {
         host = "127.0.0.1"
         port = 4869
         neverDeleteFrom = emptySet()
+        preservedKindsFromDeletion = setOf(0, 3, 10002)
         name = "Citrine"
         ownerPubkey = ""
         contact = ""

--- a/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
@@ -15,6 +15,7 @@ object PrefKeys {
     const val HOST = "host"
     const val PORT = "port"
     const val NEVER_DELETE_FROM = "never_delete_from"
+    const val PRESERVED_KINDS_FROM_DELETION = "preserved_kinds_from_deletion"
     const val RELAY_NAME = "relay_name"
     const val RELAY_OWNER_PUBKEY = "relay_owner_pubkey"
     const val RELAY_CONTACT = "relay_contact"
@@ -64,6 +65,10 @@ object LocalPreferences {
                 putString(PrefKeys.HOST, settings.host)
                 putInt(PrefKeys.PORT, settings.port)
                 putStringSet(PrefKeys.NEVER_DELETE_FROM, settings.neverDeleteFrom)
+                putString(
+                    PrefKeys.PRESERVED_KINDS_FROM_DELETION,
+                    settings.preservedKindsFromDeletion.joinToString(","),
+                )
                 putString(PrefKeys.RELAY_NAME, settings.name)
                 putString(PrefKeys.RELAY_OWNER_PUBKEY, settings.ownerPubkey)
                 putString(PrefKeys.RELAY_CONTACT, settings.contact)
@@ -110,6 +115,11 @@ object LocalPreferences {
         Settings.host = prefs.getString(PrefKeys.HOST, "127.0.0.1") ?: "127.0.0.1"
         Settings.port = prefs.getInt(PrefKeys.PORT, 4869)
         Settings.neverDeleteFrom = prefs.getStringSet(PrefKeys.NEVER_DELETE_FROM, emptySet()) ?: emptySet()
+        Settings.preservedKindsFromDeletion = prefs.getString(PrefKeys.PRESERVED_KINDS_FROM_DELETION, null)
+            ?.split(",")
+            ?.mapNotNull { it.toIntOrNull() }
+            ?.toSet()
+            ?: setOf(0, 3, 10002)
         Settings.name = prefs.getString(PrefKeys.RELAY_NAME, "Citrine") ?: "Citrine"
         Settings.ownerPubkey = prefs.getString(PrefKeys.RELAY_OWNER_PUBKEY, "") ?: ""
         Settings.contact = prefs.getString(PrefKeys.RELAY_CONTACT, "") ?: ""

--- a/app/src/main/java/com/greenart7c3/citrine/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/SettingsScreen.kt
@@ -111,6 +111,8 @@ fun SettingsScreen(
         var allowedTaggedPubKeys by remember { mutableStateOf(Settings.allowedTaggedPubKeys) }
         var allowedKinds by remember { mutableStateOf(Settings.allowedKinds) }
         var neverDeleteFrom by remember { mutableStateOf(Settings.neverDeleteFrom) }
+        var preservedKindsFromDeletion by remember { mutableStateOf(Settings.preservedKindsFromDeletion) }
+        var preservedKindInput by remember { mutableStateOf(TextFieldValue("")) }
 
         var relayAggregatorEnabled by remember { mutableStateOf(Settings.relayAggregatorEnabled) }
         var aggregatorPubkey by remember { mutableStateOf(TextFieldValue(Settings.aggregatorPubkey)) }
@@ -858,6 +860,57 @@ fun SettingsScreen(
                         val users = Settings.neverDeleteFrom.toMutableSet().apply { remove(pubkey) }
                         Settings.neverDeleteFrom = users
                         neverDeleteFrom = users
+                        LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                    },
+                )
+            }
+
+            // ── Preserved kinds ────────────────────────────────────────────────
+            stickyHeader {
+                SectionHeader(stringResource(R.string.preserved_kinds_from_deletion))
+            }
+            item {
+                EmptyListHint(stringResource(R.string.preserved_kinds_from_deletion_description))
+            }
+            item {
+                PubkeyInputRow(
+                    value = preservedKindInput,
+                    onValueChange = { preservedKindInput = it },
+                    onPaste = {
+                        scope.launch {
+                            val text = clipboardManager.getClipEntry()?.clipData?.getItemAt(0)?.text?.toString() ?: return@launch
+                            preservedKindInput = TextFieldValue(text)
+                            if (text.toIntOrNull() == null) {
+                                Toast.makeText(context, context.getString(R.string.invalid_kind), Toast.LENGTH_SHORT).show()
+                                return@launch
+                            }
+                            val kinds = Settings.preservedKindsFromDeletion.toMutableSet().apply { add(text.toInt()) }
+                            Settings.preservedKindsFromDeletion = kinds
+                            preservedKindsFromDeletion = kinds
+                            LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                            preservedKindInput = TextFieldValue("")
+                        }
+                    },
+                    onAdd = {
+                        if (preservedKindInput.text.toIntOrNull() == null) {
+                            Toast.makeText(context, context.getString(R.string.invalid_kind), Toast.LENGTH_SHORT).show()
+                            return@PubkeyInputRow
+                        }
+                        val kinds = Settings.preservedKindsFromDeletion.toMutableSet().apply { add(preservedKindInput.text.toInt()) }
+                        Settings.preservedKindsFromDeletion = kinds
+                        preservedKindsFromDeletion = kinds
+                        LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                        preservedKindInput = TextFieldValue("")
+                    },
+                )
+            }
+            items(preservedKindsFromDeletion.toList()) { k ->
+                PubkeyListItem(
+                    text = k.toString(),
+                    onDelete = {
+                        val kinds = Settings.preservedKindsFromDeletion.toMutableSet().apply { remove(k) }
+                        Settings.preservedKindsFromDeletion = kinds
+                        preservedKindsFromDeletion = kinds
                         LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
                     },
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,8 @@
     <string name="others">Others</string>
     <string name="invalid_port">Invalid port</string>
     <string name="never_delete_from">Never delete from</string>
+    <string name="preserved_kinds_from_deletion">Preserved kinds</string>
+    <string name="preserved_kinds_from_deletion_description">Events of these kinds are never removed by the age-based cleanup, regardless of the \"delete events older than\" setting.</string>
     <string name="name_access_client_with_name_localhost_port">Name (access client with name.localhost:port)</string>
     <string name="name_cannot_be_blank">Name cannot be blank</string>
     <string name="copy_crash_report_to_clipboard">Would you like to copy the crash report to your clipboard and open a Client to send it to Amber?</string>


### PR DESCRIPTION
## Summary
This PR adds a new "Preserved kinds" feature that allows users to specify event kinds that should never be deleted by the age-based cleanup mechanism, regardless of the "delete events older than" setting.

## Key Changes
- **Settings UI**: Added a new settings section in `SettingsScreen.kt` to manage preserved kinds with add/remove functionality
- **Settings Storage**: 
  - Added `preservedKindsFromDeletion` property to `Settings` object with default kinds (0, 3, 10002)
  - Added persistence layer in `LocalPreferences.kt` to save/load preserved kinds as comma-separated integers
- **Database Queries**: Extended `EventDao.kt` with two new overloaded `deleteAll()` methods:
  - One that excludes specific kinds from deletion
  - One that excludes both specific pubkeys and kinds from deletion
- **Deletion Logic**: Updated `Citrine.kt` to handle four deletion scenarios:
  - No exclusions (delete all old events)
  - Only preserved kinds (exclude by kind)
  - Only never-delete pubkeys (exclude by pubkey)
  - Both preserved kinds and pubkeys (exclude by both)
- **Localization**: Added UI strings for the new feature in `strings.xml`

## Implementation Details
- Default preserved kinds are set to `{0, 3, 10002}` (metadata, text notes, and relay list metadata)
- The feature uses a `Set<Int>` for efficient kind lookups during deletion
- Input validation ensures only valid integer kinds can be added
- The UI reuses existing `PubkeyInputRow` and `PubkeyListItem` components for consistency

https://claude.ai/code/session_01Lm2yqwGPsqMACS3c8SafYs