### PR TITLE
Add option to route all URLs through Tor proxy

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/Citrine.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/Citrine.kt
@@ -39,7 +39,25 @@ class Citrine : Application() {
         }
     val applicationScope = CoroutineScope(Dispatchers.IO + SupervisorJob() + exceptionHandler)
     val factory = OkHttpWebSocket.Builder { url ->
-        HttpClientManager.getHttpClient(if (isPrivateIp(url.url)) false else Settings.useProxy)
+        HttpClientManager.getHttpClient(shouldUseProxyFor(url.url))
+    }
+
+    fun shouldUseProxyFor(url: String): Boolean {
+        if (!Settings.useProxy) return false
+        if (isPrivateIp(url)) return false
+        if (Settings.proxyAllUrls) return true
+        return isOnionUrl(url)
+    }
+
+    fun isOnionUrl(url: String): Boolean {
+        val host = url
+            .substringAfter("://", url)
+            .substringBefore('/')
+            .substringBefore('?')
+            .substringBefore('#')
+            .substringBefore(':')
+            .lowercase()
+        return host.endsWith(".onion")
     }
     val client: NostrClient = NostrClient(factory, applicationScope)
 

--- a/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
@@ -25,6 +25,7 @@ object Settings {
     var startOnBoot = true
     var lastBackup: Long = 0L
     var useProxy = false
+    var proxyAllUrls = false
     var useTor = false
     var onionHostname = ""
     var webClients = mutableMapOf<String, String>()
@@ -66,6 +67,7 @@ object Settings {
         startOnBoot = true
         lastBackup = 0L
         useProxy = false
+        proxyAllUrls = false
         useTor = false
         onionHostname = ""
         webClients = mutableMapOf()

--- a/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
@@ -124,7 +124,9 @@ object LocalPreferences {
         Settings.startOnBoot = prefs.getBoolean(PrefKeys.START_ON_BOOT, true)
         Settings.lastBackup = prefs.getLong(PrefKeys.LAST_BACKUP, 0)
         Settings.useProxy = prefs.getBoolean(PrefKeys.USE_PROXY, false)
-        Settings.proxyAllUrls = prefs.getBoolean(PrefKeys.PROXY_ALL_URLS, false)
+        // Migration: pre-existing installs with proxy enabled used to route every URL through Tor.
+        // Preserve that behavior unless the user has explicitly chosen otherwise.
+        Settings.proxyAllUrls = prefs.getBoolean(PrefKeys.PROXY_ALL_URLS, Settings.useProxy)
         Settings.useTor = prefs.getBoolean(PrefKeys.USE_TOR, false)
         Settings.onionHostname = prefs.getString(PrefKeys.ONION_HOSTNAME, "") ?: ""
         prefs.getString(PrefKeys.WEB_CLIENTS, null)?.let {

--- a/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
@@ -27,6 +27,7 @@ object PrefKeys {
     const val START_ON_BOOT = "start_on_boot"
     const val LAST_BACKUP = "last_backup"
     const val USE_PROXY = "use_proxy"
+    const val PROXY_ALL_URLS = "proxy_all_urls"
     const val USE_TOR = "use_tor"
     const val ONION_HOSTNAME = "onion_hostname"
 
@@ -76,6 +77,7 @@ object LocalPreferences {
                 putBoolean(PrefKeys.START_ON_BOOT, settings.startOnBoot)
                 putLong(PrefKeys.LAST_BACKUP, settings.lastBackup)
                 putBoolean(PrefKeys.USE_PROXY, settings.useProxy)
+                putBoolean(PrefKeys.PROXY_ALL_URLS, settings.proxyAllUrls)
                 putBoolean(PrefKeys.USE_TOR, settings.useTor)
                 putString(PrefKeys.ONION_HOSTNAME, settings.onionHostname)
                 if (Settings.webClients.isNotEmpty()) {
@@ -122,6 +124,7 @@ object LocalPreferences {
         Settings.startOnBoot = prefs.getBoolean(PrefKeys.START_ON_BOOT, true)
         Settings.lastBackup = prefs.getLong(PrefKeys.LAST_BACKUP, 0)
         Settings.useProxy = prefs.getBoolean(PrefKeys.USE_PROXY, false)
+        Settings.proxyAllUrls = prefs.getBoolean(PrefKeys.PROXY_ALL_URLS, false)
         Settings.useTor = prefs.getBoolean(PrefKeys.USE_TOR, false)
         Settings.onionHostname = prefs.getString(PrefKeys.ONION_HOSTNAME, "") ?: ""
         prefs.getString(PrefKeys.WEB_CLIENTS, null)?.let {

--- a/app/src/main/java/com/greenart7c3/citrine/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/SettingsScreen.kt
@@ -98,6 +98,7 @@ fun SettingsScreen(
         var useAuth by remember { mutableStateOf(Settings.authEnabled) }
         var listenToPokeyBroadcasts by remember { mutableStateOf(Settings.listenToPokeyBroadcasts) }
         var useProxy by remember { mutableStateOf(Settings.useProxy) }
+        var proxyAllUrls by remember { mutableStateOf(Settings.proxyAllUrls) }
         var useTor by remember { mutableStateOf(Settings.useTor) }
         val torState = com.greenart7c3.citrine.service.TorManager.state.collectAsStateWithLifecycle()
         var autoBackup by remember { mutableStateOf(Settings.autoBackup) }
@@ -747,6 +748,20 @@ fun SettingsScreen(
                         LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
                     },
                 )
+            }
+            if (useProxy) {
+                item {
+                    SwitchSettingRow(
+                        title = stringResource(R.string.proxy_all_urls),
+                        description = stringResource(R.string.proxy_all_urls_description),
+                        checked = proxyAllUrls,
+                        onCheckedChange = {
+                            proxyAllUrls = it
+                            Settings.proxyAllUrls = it
+                            LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                        },
+                    )
+                }
             }
             item {
                 SwitchSettingRow(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,7 +112,9 @@
     <string name="listen_to_pokey_broadcasts_description">Receive events broadcast by the Pokey app</string>
     <string name="delete_expired_events_description">Automatically remove events past their expiration timestamp</string>
     <string name="delete_ephemeral_events_description">Automatically remove ephemeral events (kinds 20000–29999)</string>
-    <string name="use_proxy_description">Route outbound connections through the embedded Tor daemon</string>
+    <string name="use_proxy_description">Route outbound connections through the embedded Tor daemon. By default only .onion URLs are routed through Tor.</string>
+    <string name="proxy_all_urls">Use Tor for all URLs</string>
+    <string name="proxy_all_urls_description">Route every outbound connection through Tor, not just .onion addresses</string>
     <string name="auto_backup_description">Periodically back up the database to a selected folder</string>
     <string name="use_tor">Expose relay over Tor</string>
     <string name="use_tor_description">Run an onion service so other Nostr clients can reach this relay over the Tor network</string>


### PR DESCRIPTION
## Summary
This PR adds granular control over which URLs are routed through the Tor proxy. Previously, when proxy mode was enabled, the behavior was implicit. Now users can choose between routing only .onion addresses through Tor (new default) or routing all URLs through Tor (preserving the old behavior for existing users).

## Key Changes
- **New proxy routing logic**: Added `shouldUseProxyFor()` method that respects three conditions:
  - Global proxy setting must be enabled
  - URL must not be a private IP address
  - URL must either be a .onion address OR the new `proxyAllUrls` setting must be enabled

- **Onion URL detection**: Implemented `isOnionUrl()` helper that extracts the hostname from a URL and checks if it ends with `.onion`

- **Settings UI**: Added a new toggle "Use Tor for all URLs" that only appears when proxy mode is enabled, allowing users to opt-in to routing all connections through Tor

- **Persistent storage**: Added `PROXY_ALL_URLS` preference key and integrated it into the settings save/load flow

- **Migration support**: Pre-existing installations with proxy enabled will automatically have `proxyAllUrls` set to `true`, preserving the previous behavior unless explicitly changed by the user

- **Updated documentation**: Clarified the proxy description text to explain the new selective routing behavior

## Implementation Details
- The proxy decision logic is now centralized in `shouldUseProxyFor()` rather than being inline in the factory builder
- The onion URL detection uses string manipulation to safely extract the hostname regardless of URL format (with or without port, query params, fragments)
- The migration logic ensures backward compatibility by defaulting new installs to `false` while existing installs default to `true`

https://claude.ai/code/session_01NVJJmgYSLVsjRJSpnn5pud