### PR TITLE
Add NIP-77 Negentropy protocol support for efficient event sync

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -228,4 +228,5 @@ dependencies {
     implementation(libs.kmp.tor.runtime.service)
     implementation(libs.kmp.tor.runtime.service.ui)
     implementation(libs.kmp.tor.resource.exec)
+    implementation(libs.negentropy)
 }

--- a/app/src/main/java/com/greenart7c3/citrine/database/EventDao.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/EventDao.kt
@@ -28,6 +28,9 @@ interface EventDao {
     @RawQuery
     fun count(query: SupportSQLiteQuery): Int
 
+    @RawQuery
+    fun getIdsAndCreatedAt(query: SupportSQLiteQuery): List<IdAndCreatedAt>
+
     @Query("SELECT kind, COUNT(*) count FROM EventEntity GROUP BY kind ORDER BY kind ASC")
     fun countByKind(): Flow<List<CountResult>>
 

--- a/app/src/main/java/com/greenart7c3/citrine/database/IdAndCreatedAt.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/IdAndCreatedAt.kt
@@ -1,0 +1,6 @@
+package com.greenart7c3.citrine.database
+
+data class IdAndCreatedAt(
+    val id: String,
+    val createdAt: Long,
+)

--- a/app/src/main/java/com/greenart7c3/citrine/server/AuthGate.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/AuthGate.kt
@@ -1,0 +1,39 @@
+package com.greenart7c3.citrine.server
+
+import com.greenart7c3.citrine.utils.KINDS_PRIVATE_EVENTS
+
+object AuthGate {
+    enum class Denial { AUTH_REQUIRED, RESTRICTED }
+
+    fun check(filter: EventFilter, connection: Connection): Denial? {
+        if (!Settings.authEnabled) return null
+
+        for (kind in filter.kinds) {
+            if (KINDS_PRIVATE_EVENTS.contains(kind)) {
+                if (connection.users.isEmpty()) return Denial.AUTH_REQUIRED
+
+                val senders = filter.authors
+                val receivers = filter.tags.filter { it.key == "p" }
+                if (!senders.any { connection.users.contains(it) } &&
+                    !receivers.any { entry -> entry.value.any { receiver -> connection.users.contains(receiver) } }
+                ) {
+                    return Denial.RESTRICTED
+                }
+            }
+        }
+
+        if (filter.kinds.isEmpty() && (filter.tags.contains("p") || filter.authors.isNotEmpty())) {
+            if (connection.users.isEmpty()) return Denial.AUTH_REQUIRED
+
+            val senders = filter.authors
+            val receivers = filter.tags.filter { it.key == "#p" }
+            if (!senders.any { connection.users.contains(it) } &&
+                !receivers.any { entry -> entry.value.any { receiver -> connection.users.contains(receiver) } }
+            ) {
+                return Denial.RESTRICTED
+            }
+        }
+
+        return null
+    }
+}

--- a/app/src/main/java/com/greenart7c3/citrine/server/Connection.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Connection.kt
@@ -3,10 +3,12 @@ package com.greenart7c3.citrine.server
 import android.util.Log
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.service.CustomWebSocketService
+import com.vitorpamplona.negentropy.Negentropy
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import io.ktor.server.websocket.DefaultWebSocketServerSession
 import io.ktor.websocket.Frame
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -25,6 +27,8 @@ class Connection(
 ) {
     val messageResponseFlow = MutableSharedFlow<String>()
     val sharedFlow = messageResponseFlow.asSharedFlow()
+
+    val negentropySessions: MutableMap<String, Negentropy> = ConcurrentHashMap()
 
     val since = System.currentTimeMillis()
     private val inactivityJob: Job = Citrine.instance.applicationScope.launch {
@@ -56,6 +60,7 @@ class Connection(
     fun finalize() {
         inactivityJob.cancel()
         EventSubscription.closeAll(name)
+        negentropySessions.clear()
     }
 
     fun trySend(data: String) {

--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -275,6 +275,36 @@ class CustomWebSocketServer(
                     EventSubscription.close(msgArray.get(1).asText())
                 }
 
+                "NEG-OPEN" -> {
+                    connection?.let {
+                        NegentropyHandler.handleOpen(
+                            connection = it,
+                            subId = msgArray.get(1).asText(),
+                            filterNode = msgArray.get(2),
+                            initialMsgHex = msgArray.get(3).asText(),
+                            appDatabase = appDatabase,
+                            objectMapper = objectMapper,
+                        )
+                    }
+                }
+
+                "NEG-MSG" -> {
+                    connection?.let {
+                        NegentropyHandler.handleMsg(
+                            connection = it,
+                            subId = msgArray.get(1).asText(),
+                            msgHex = msgArray.get(2).asText(),
+                            objectMapper = objectMapper,
+                        )
+                    }
+                }
+
+                "NEG-CLOSE" -> {
+                    connection?.let {
+                        NegentropyHandler.handleClose(it, msgArray.get(1).asText())
+                    }
+                }
+
                 "PING" -> {
                     try {
                         connection?.trySend(NoticeResult("PONG").toJson())
@@ -989,7 +1019,7 @@ class CustomWebSocketServer(
                     } else if (call.request.headers["Accept"] == "application/nostr+json") {
                         LocalPreferences.loadSettingsFromEncryptedStorage(Citrine.instance)
 
-                        val supportedNips = mutableListOf(1, 2, 4, 9, 11, 40, 45, 50, 59, 65, 70)
+                        val supportedNips = mutableListOf(1, 2, 4, 9, 11, 40, 45, 50, 59, 65, 70, 77)
                         if (Settings.authEnabled) supportedNips.add(42)
 
                         call.respondText(

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.EventWithTags
+import com.greenart7c3.citrine.database.IdAndCreatedAt
 import com.greenart7c3.citrine.database.toEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
@@ -17,9 +18,15 @@ private val TAG_KEY_REGEX = Regex("^[a-zA-Z0-9]+$")
 private val JACKSON_NODE_FACTORY = JacksonMapper.mapper.nodeFactory
 
 object EventRepository {
+    enum class SelectMode {
+        FULL_EVENTS,
+        COUNT,
+        IDS_AND_CREATED_AT,
+    }
+
     fun createQuery(
         filter: EventFilter,
-        count: Boolean,
+        mode: SelectMode,
     ): Pair<String, List<Any>> {
         val params = mutableListOf<Any>()
         val joinClause = StringBuilder()
@@ -113,17 +120,28 @@ object EventRepository {
         }
 
         val query = StringBuilder()
-        if (count) {
-            query.append("SELECT COUNT(DISTINCT EventEntity.id) FROM EventEntity EventEntity")
-            query.append(joinClause)
-            query.append(whereClause)
-        } else {
-            query.append("SELECT ")
-            if (filter.tags.isNotEmpty()) query.append("DISTINCT ")
-            query.append("EventEntity.* FROM EventEntity EventEntity")
-            query.append(joinClause)
-            query.append(whereClause)
-            query.append(" ORDER BY ").append(orderBy)
+        when (mode) {
+            SelectMode.COUNT -> {
+                query.append("SELECT COUNT(DISTINCT EventEntity.id) FROM EventEntity EventEntity")
+                query.append(joinClause)
+                query.append(whereClause)
+            }
+            SelectMode.FULL_EVENTS -> {
+                query.append("SELECT ")
+                if (filter.tags.isNotEmpty()) query.append("DISTINCT ")
+                query.append("EventEntity.* FROM EventEntity EventEntity")
+                query.append(joinClause)
+                query.append(whereClause)
+                query.append(" ORDER BY ").append(orderBy)
+            }
+            SelectMode.IDS_AND_CREATED_AT -> {
+                query.append("SELECT ")
+                if (filter.tags.isNotEmpty()) query.append("DISTINCT ")
+                query.append("EventEntity.id AS id, EventEntity.createdAt AS createdAt FROM EventEntity EventEntity")
+                query.append(joinClause)
+                query.append(whereClause)
+                query.append(" ORDER BY ").append(orderBy)
+            }
         }
 
         filter.limit?.let {
@@ -137,7 +155,7 @@ object EventRepository {
         database: AppDatabase,
         filter: EventFilter,
     ): List<EventWithTags> {
-        val query = createQuery(filter, false)
+        val query = createQuery(filter, SelectMode.FULL_EVENTS)
 
         val rawSql = SimpleSQLiteQuery(query.first, query.second.toTypedArray())
         return database.eventDao().getEvents(rawSql)
@@ -147,10 +165,20 @@ object EventRepository {
         database: AppDatabase,
         filter: EventFilter,
     ): Int {
-        val query = createQuery(filter, true)
+        val query = createQuery(filter, SelectMode.COUNT)
 
         val rawSql = SimpleSQLiteQuery(query.first, query.second.toTypedArray())
         return database.eventDao().count(rawSql)
+    }
+
+    fun idsAndCreatedAt(
+        database: AppDatabase,
+        filter: EventFilter,
+    ): List<IdAndCreatedAt> {
+        val query = createQuery(filter, SelectMode.IDS_AND_CREATED_AT)
+
+        val rawSql = SimpleSQLiteQuery(query.first, query.second.toTypedArray())
+        return database.eventDao().getIdsAndCreatedAt(rawSql)
     }
 
     fun subscribe(

--- a/app/src/main/java/com/greenart7c3/citrine/server/NegentropyHandler.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/NegentropyHandler.kt
@@ -1,0 +1,123 @@
+package com.greenart7c3.citrine.server
+
+import android.util.Log
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.greenart7c3.citrine.Citrine
+import com.greenart7c3.citrine.database.AppDatabase
+import com.vitorpamplona.negentropy.Negentropy
+import com.vitorpamplona.negentropy.storage.StorageVector
+
+@OptIn(ExperimentalStdlibApi::class)
+object NegentropyHandler {
+    private const val FRAME_SIZE_LIMIT = 50_000L
+    private const val MAX_EVENTS = 1_000_000
+
+    suspend fun handleOpen(
+        connection: Connection,
+        subId: String,
+        filterNode: JsonNode,
+        initialMsgHex: String,
+        appDatabase: AppDatabase,
+        objectMapper: ObjectMapper,
+    ) {
+        val filter = parseFilter(filterNode, objectMapper)
+
+        when (AuthGate.check(filter, connection)) {
+            AuthGate.Denial.AUTH_REQUIRED -> {
+                connection.trySend(negError(objectMapper, subId, "auth-required: we only accept events from registered users"))
+                return
+            }
+            AuthGate.Denial.RESTRICTED -> {
+                connection.trySend(negError(objectMapper, subId, "restricted: we only accept events from registered users"))
+                return
+            }
+            null -> Unit
+        }
+
+        val matchCount = EventRepository.countQuery(appDatabase, filter)
+        if (matchCount > MAX_EVENTS) {
+            connection.trySend(
+                objectMapper.writeValueAsString(
+                    listOf("NEG-ERR", subId, "blocked: query too big", MAX_EVENTS),
+                ),
+            )
+            return
+        }
+
+        val storage = StorageVector().apply {
+            EventRepository.idsAndCreatedAt(appDatabase, filter).forEach {
+                insert(it.createdAt, it.id)
+            }
+            seal()
+        }
+
+        val ne = Negentropy(storage, FRAME_SIZE_LIMIT)
+        connection.negentropySessions.put(subId, ne)
+
+        val response = try {
+            ne.reconcile(initialMsgHex.hexToByteArray())
+        } catch (e: Exception) {
+            Log.d(Citrine.TAG, "negentropy reconcile failed on NEG-OPEN $subId", e)
+            connection.negentropySessions.remove(subId)
+            connection.trySend(negError(objectMapper, subId, "error: ${e.message ?: "reconcile failed"}"))
+            return
+        }
+
+        val msg = response.msg
+        if (msg == null) {
+            connection.negentropySessions.remove(subId)
+        }
+        connection.trySend(
+            objectMapper.writeValueAsString(
+                listOf("NEG-MSG", subId, (msg ?: ByteArray(0)).toHexString()),
+            ),
+        )
+    }
+
+    fun handleMsg(
+        connection: Connection,
+        subId: String,
+        msgHex: String,
+        objectMapper: ObjectMapper,
+    ) {
+        val ne = connection.negentropySessions[subId]
+        if (ne == null) {
+            connection.trySend(negError(objectMapper, subId, "closed: unknown subscription"))
+            return
+        }
+
+        val response = try {
+            ne.reconcile(msgHex.hexToByteArray())
+        } catch (e: Exception) {
+            Log.d(Citrine.TAG, "negentropy reconcile failed on NEG-MSG $subId", e)
+            connection.negentropySessions.remove(subId)
+            connection.trySend(negError(objectMapper, subId, "error: ${e.message ?: "reconcile failed"}"))
+            return
+        }
+
+        val msg = response.msg
+        if (msg == null) {
+            connection.negentropySessions.remove(subId)
+        }
+        connection.trySend(
+            objectMapper.writeValueAsString(
+                listOf("NEG-MSG", subId, (msg ?: ByteArray(0)).toHexString()),
+            ),
+        )
+    }
+
+    fun handleClose(connection: Connection, subId: String) {
+        connection.negentropySessions.remove(subId)
+    }
+
+    private fun parseFilter(node: JsonNode, objectMapper: ObjectMapper): EventFilter {
+        val tags = node.properties().asSequence()
+            .filter { it.key.startsWith("#") }
+            .associate { entry -> entry.key.substringAfter("#") to entry.value.map { it.asText() }.toSet() }
+        val base = objectMapper.treeToValue(node, EventFilter::class.java)
+        return base.copy(tags = tags)
+    }
+
+    private fun negError(objectMapper: ObjectMapper, subId: String, reason: String): String = objectMapper.writeValueAsString(listOf("NEG-ERR", subId, reason))
+}

--- a/app/src/main/java/com/greenart7c3/citrine/server/SubscriptionManager.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/SubscriptionManager.kt
@@ -2,7 +2,6 @@ package com.greenart7c3.citrine.server
 
 import android.util.Log
 import com.greenart7c3.citrine.Citrine
-import com.greenart7c3.citrine.utils.KINDS_PRIVATE_EVENTS
 import kotlin.time.measureTime
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -22,41 +21,18 @@ class SubscriptionManager(
             }
 
             for (filter in subscription.filters) {
-                // Check pubkey auth - require authentication for private events and filters with p tags/authors
-                if (Settings.authEnabled) {
-                    for (kind in filter.kinds) {
-                        if (KINDS_PRIVATE_EVENTS.contains(kind)) {
-                            if (subscription.connection.users.isEmpty()) {
-                                Log.d(Citrine.TAG, "cancelling subscription auth-required: ${subscription.id}")
-                                subscription.connection.trySend(ClosedResult.required(subscription.id).toJson())
-                                return@launch
-                            }
-
-                            val senders = filter.authors
-                            val receivers = filter.tags.filter { it.key == "p" }
-                            if (!senders.any { subscription.connection.users.contains(it) } && !receivers.any { it.value.any { receiver -> subscription.connection.users.contains(receiver) } }) {
-                                Log.d(Citrine.TAG, "cancelling subscription restricted: ${subscription.id} senders: $senders receivers: $receivers authed users: ${subscription.connection.users} filter: $filter")
-                                subscription.connection.trySend(ClosedResult.restricted(subscription.id).toJson())
-                                return@launch
-                            }
-                        }
+                when (AuthGate.check(filter, subscription.connection)) {
+                    AuthGate.Denial.AUTH_REQUIRED -> {
+                        Log.d(Citrine.TAG, "cancelling subscription auth-required: ${subscription.id}")
+                        subscription.connection.trySend(ClosedResult.required(subscription.id).toJson())
+                        return@launch
                     }
-
-                    if (filter.kinds.isEmpty() && (filter.tags.contains("p") || filter.authors.isNotEmpty())) {
-                        if (subscription.connection.users.isEmpty()) {
-                            Log.d(Citrine.TAG, "cancelling subscription auth-required: ${subscription.id}")
-                            subscription.connection.trySend(ClosedResult.required(subscription.id).toJson())
-                            return@launch
-                        }
-
-                        val senders = filter.authors
-                        val receivers = filter.tags.filter { it.key == "#p" }
-                        if (!senders.any { subscription.connection.users.contains(it) } && !receivers.any { it.value.any { receiver -> subscription.connection.users.contains(receiver) } }) {
-                            Log.d(Citrine.TAG, "cancelling subscription restricted: ${subscription.id} senders: $senders receivers: $receivers authed user: ${subscription.connection.users} filter: $filter")
-                            subscription.connection.trySend(ClosedResult.restricted(subscription.id).toJson())
-                            return@launch
-                        }
+                    AuthGate.Denial.RESTRICTED -> {
+                        Log.d(Citrine.TAG, "cancelling subscription restricted: ${subscription.id} filter: $filter authed users: ${subscription.connection.users}")
+                        subscription.connection.trySend(ClosedResult.restricted(subscription.id).toJson())
+                        return@launch
                     }
+                    null -> Unit
                 }
 
                 try {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ collections = "0.4.0"
 pagingCommon = "3.4.2"
 kmpTor = "2.6.0"
 kmpTorResource = "409.5.0"
+negentropy = "1.0.1"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -70,6 +71,7 @@ kmp-tor-runtime = { module = "io.matthewnelson.kmp-tor:runtime", version.ref = "
 kmp-tor-runtime-service = { module = "io.matthewnelson.kmp-tor:runtime-service", version.ref = "kmpTor" }
 kmp-tor-runtime-service-ui = { module = "io.matthewnelson.kmp-tor:runtime-service-ui", version.ref = "kmpTor" }
 kmp-tor-resource-exec = { module = "io.matthewnelson.kmp-tor:resource-exec-tor", version.ref = "kmpTorResource" }
+negentropy = { module = "com.vitorpamplona.negentropy:kmp-negentropy-android", version.ref = "negentropy" }
 
 [plugins]
 jetbrainsComposeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary
This PR adds support for NIP-77 (Negentropy protocol) to enable efficient event synchronization between clients and the server. The Negentropy protocol allows clients to reconcile their local event cache with the server's events using a set reconciliation algorithm, reducing bandwidth and improving sync performance.

## Key Changes

- **New `NegentropyHandler` object**: Implements the three-message Negentropy protocol flow
  - `handleOpen()`: Initiates reconciliation with a filter and initial message
  - `handleMsg()`: Processes subsequent reconciliation messages
  - `handleClose()`: Cleans up session state
  - Includes auth checks via `AuthGate` to enforce access control
  - Validates query size to prevent resource exhaustion (max 1M events)

- **New `AuthGate` object**: Extracted authentication logic for reusability
  - Centralizes authorization checks for private events and filtered queries
  - Returns `Denial` enum indicating `AUTH_REQUIRED` or `RESTRICTED` status
  - Used by both subscription manager and Negentropy handler

- **Enhanced `EventRepository`**: Added support for multiple query modes
  - New `SelectMode` enum: `FULL_EVENTS`, `COUNT`, `IDS_AND_CREATED_AT`
  - New `idsAndCreatedAt()` function to fetch only event IDs and timestamps (optimized for Negentropy)
  - Refactored `createQuery()` to support all three modes

- **WebSocket message handlers**: Added NEG-OPEN, NEG-MSG, and NEG-CLOSE message handling in `CustomWebSocketServer`

- **Connection session management**: Added `negentropySessions` map to track active Negentropy reconciliation sessions per subscription ID

- **Database support**: New `IdAndCreatedAt` data class and `EventDao.getIdsAndCreatedAt()` query method

- **NIP support**: Added NIP-77 to the server's supported NIPs list

- **Dependencies**: Added Negentropy library (v1.0.1)

## Implementation Details

- Negentropy sessions are stored per connection and keyed by subscription ID
- Frame size is limited to 50KB to manage message sizes
- Query results are capped at 1M events to prevent DoS attacks
- Auth checks ensure only authenticated users can sync private events
- Sessions are cleaned up when reconciliation completes (when response message is null)
- Error handling includes detailed logging and user-friendly error messages

https://claude.ai/code/session_01AcsqqXKJqbTcuvuguRsm6m