### PR TITLE
Add NIP-42 AUTH support via external signer integration

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/Citrine.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/Citrine.kt
@@ -1,14 +1,12 @@
 package com.greenart7c3.citrine
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.app.AlarmManager
 import android.app.Application
 import android.app.PendingIntent
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
-import android.os.Bundle
 import android.util.Log
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.okhttp.HttpClientManager
@@ -65,31 +63,6 @@ class Citrine : Application() {
 
     private val pokeyReceiver = PokeyReceiver()
 
-    // Tracks the currently-resumed Activity so headless callers (e.g. RelayAggregator's
-    // foreground signer launcher) can route Activity-context-requiring intents through a
-    // real Activity instead of resorting to FLAG_ACTIVITY_NEW_TASK from the Application
-    // context — the latter nulls the caller's UID, which breaks Amber's setResult round
-    // trip.
-    @Volatile
-    var currentActivity: Activity? = null
-        private set
-
-    private val activityLifecycleCallbacks = object : Application.ActivityLifecycleCallbacks {
-        override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
-        override fun onActivityStarted(activity: Activity) {}
-        override fun onActivityResumed(activity: Activity) {
-            currentActivity = activity
-        }
-        override fun onActivityPaused(activity: Activity) {
-            if (currentActivity === activity) currentActivity = null
-        }
-        override fun onActivityStopped(activity: Activity) {}
-        override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
-        override fun onActivityDestroyed(activity: Activity) {
-            if (currentActivity === activity) currentActivity = null
-        }
-    }
-
     fun isPrivateIp(url: String): Boolean = url.contains("127.0.0.1") ||
         url.contains("localhost") ||
         url.contains("192.168.") ||
@@ -134,8 +107,6 @@ class Citrine : Application() {
         super.onCreate()
 
         instance = this
-
-        registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
 
         Thread.setDefaultUncaughtExceptionHandler(UnexpectedCrashSaver(crashReportCache, applicationScope))
 

--- a/app/src/main/java/com/greenart7c3/citrine/Citrine.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/Citrine.kt
@@ -1,12 +1,14 @@
 package com.greenart7c3.citrine
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.app.AlarmManager
 import android.app.Application
 import android.app.PendingIntent
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
+import android.os.Bundle
 import android.util.Log
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.okhttp.HttpClientManager
@@ -63,6 +65,31 @@ class Citrine : Application() {
 
     private val pokeyReceiver = PokeyReceiver()
 
+    // Tracks the currently-resumed Activity so headless callers (e.g. RelayAggregator's
+    // foreground signer launcher) can route Activity-context-requiring intents through a
+    // real Activity instead of resorting to FLAG_ACTIVITY_NEW_TASK from the Application
+    // context — the latter nulls the caller's UID, which breaks Amber's setResult round
+    // trip.
+    @Volatile
+    var currentActivity: Activity? = null
+        private set
+
+    private val activityLifecycleCallbacks = object : Application.ActivityLifecycleCallbacks {
+        override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+        override fun onActivityStarted(activity: Activity) {}
+        override fun onActivityResumed(activity: Activity) {
+            currentActivity = activity
+        }
+        override fun onActivityPaused(activity: Activity) {
+            if (currentActivity === activity) currentActivity = null
+        }
+        override fun onActivityStopped(activity: Activity) {}
+        override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+        override fun onActivityDestroyed(activity: Activity) {
+            if (currentActivity === activity) currentActivity = null
+        }
+    }
+
     fun isPrivateIp(url: String): Boolean = url.contains("127.0.0.1") ||
         url.contains("localhost") ||
         url.contains("192.168.") ||
@@ -107,6 +134,8 @@ class Citrine : Application() {
         super.onCreate()
 
         instance = this
+
+        registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
 
         Thread.setDefaultUncaughtExceptionHandler(UnexpectedCrashSaver(crashReportCache, applicationScope))
 

--- a/app/src/main/java/com/greenart7c3/citrine/MainActivity.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/MainActivity.kt
@@ -1,9 +1,11 @@
 package com.greenart7c3.citrine
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.anggrayudi.storage.SimpleStorageHelper
+import com.greenart7c3.citrine.service.RelayAggregator
 import com.greenart7c3.citrine.ui.CitrineScaffold
 import com.greenart7c3.citrine.ui.theme.CitrineTheme
 
@@ -13,6 +15,11 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        // Amber returns AUTH-signed events via a fresh Intent when launched from the
+        // aggregator's application-context launcher; route it back so the suspended
+        // sign() call resumes.
+        intent?.let { RelayAggregator.deliverSignerResponse(it) }
+
         setContent {
             CitrineTheme {
                 CitrineScaffold(
@@ -20,5 +27,10 @@ class MainActivity : ComponentActivity() {
                 )
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        RelayAggregator.deliverSignerResponse(intent)
     }
 }

--- a/app/src/main/java/com/greenart7c3/citrine/MainActivity.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/MainActivity.kt
@@ -1,9 +1,9 @@
 package com.greenart7c3.citrine
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import com.anggrayudi.storage.SimpleStorageHelper
 import com.greenart7c3.citrine.service.RelayAggregator
 import com.greenart7c3.citrine.ui.CitrineScaffold
@@ -12,13 +12,21 @@ import com.greenart7c3.citrine.ui.theme.CitrineTheme
 class MainActivity : ComponentActivity() {
     private val storageHelper = SimpleStorageHelper(this@MainActivity)
 
+    // Launcher used by the aggregator's foreground signer path. Going through
+    // registerForActivityResult preserves the calling package on the intent — startActivity
+    // alone would leave Amber reading a null callingPackage and rejecting the request.
+    private val aggregatorSignerLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        result.data?.let { RelayAggregator.deliverSignerResponse(it) }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Amber returns AUTH-signed events via a fresh Intent when launched from the
-        // aggregator's application-context launcher; route it back so the suspended
-        // sign() call resumes.
-        intent?.let { RelayAggregator.deliverSignerResponse(it) }
+        RelayAggregator.registerActivityLauncher { intent ->
+            aggregatorSignerLauncher.launch(intent)
+        }
 
         setContent {
             CitrineTheme {
@@ -29,8 +37,8 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    override fun onNewIntent(intent: Intent) {
-        super.onNewIntent(intent)
-        RelayAggregator.deliverSignerResponse(intent)
+    override fun onDestroy() {
+        RelayAggregator.unregisterActivityLauncher()
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
@@ -48,11 +48,10 @@ object Settings {
     // is the dominant battery cost on cellular.
     var relayAggregatorWifiOnly: Boolean = true
 
-    // When true the aggregator answers NIP-42 AUTH challenges from upstream relays using
-    // the external signer identified by [aggregatorSignerPubkey] / [aggregatorSignerPackageName].
-    // Requires the user to first log in via the external signer so we have a packageName
-    // for the ContentResolver-based signing path.
-    var relayAggregatorAuthEnabled: Boolean = false
+    // External signer used by the aggregator to answer NIP-42 AUTH challenges from upstream
+    // relays. Populated by the "Log in with external signer" flow in settings. When both
+    // fields are set, the aggregator installs a RelayAuthenticator and signs kind-22242
+    // challenges via the configured Amber-compatible signer.
     var aggregatorSignerPubkey: String = ""
     var aggregatorSignerPackageName: String = ""
 
@@ -90,7 +89,6 @@ object Settings {
         relayAggregatorLastSync = 0L
         relayAggregatorExtraRelays = emptySet()
         relayAggregatorWifiOnly = true
-        relayAggregatorAuthEnabled = false
         aggregatorSignerPubkey = ""
         aggregatorSignerPackageName = ""
     }

--- a/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
@@ -48,6 +48,14 @@ object Settings {
     // is the dominant battery cost on cellular.
     var relayAggregatorWifiOnly: Boolean = true
 
+    // When true the aggregator answers NIP-42 AUTH challenges from upstream relays using
+    // the external signer identified by [aggregatorSignerPubkey] / [aggregatorSignerPackageName].
+    // Requires the user to first log in via the external signer so we have a packageName
+    // for the ContentResolver-based signing path.
+    var relayAggregatorAuthEnabled: Boolean = false
+    var aggregatorSignerPubkey: String = ""
+    var aggregatorSignerPackageName: String = ""
+
     fun defaultValues() {
         allowedKinds = emptySet()
         allowedPubKeys = emptySet()
@@ -82,6 +90,9 @@ object Settings {
         relayAggregatorLastSync = 0L
         relayAggregatorExtraRelays = emptySet()
         relayAggregatorWifiOnly = true
+        relayAggregatorAuthEnabled = false
+        aggregatorSignerPubkey = ""
+        aggregatorSignerPackageName = ""
     }
 
     fun webClientFromJson(json: String): MutableMap<String, String> = JacksonMapper.mapper.readValue<MutableMap<String, String>>(json)

--- a/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
@@ -42,6 +42,9 @@ object PrefKeys {
     const val RELAY_AGGREGATOR_LAST_SYNC = "relay_aggregator_last_sync"
     const val RELAY_AGGREGATOR_EXTRA_RELAYS = "relay_aggregator_extra_relays"
     const val RELAY_AGGREGATOR_WIFI_ONLY = "relay_aggregator_wifi_only"
+    const val RELAY_AGGREGATOR_AUTH_ENABLED = "relay_aggregator_auth_enabled"
+    const val AGGREGATOR_SIGNER_PUBKEY = "aggregator_signer_pubkey"
+    const val AGGREGATOR_SIGNER_PACKAGE_NAME = "aggregator_signer_package_name"
 }
 
 object LocalPreferences {
@@ -103,6 +106,9 @@ object LocalPreferences {
                 putLong(PrefKeys.RELAY_AGGREGATOR_LAST_SYNC, settings.relayAggregatorLastSync)
                 putStringSet(PrefKeys.RELAY_AGGREGATOR_EXTRA_RELAYS, settings.relayAggregatorExtraRelays)
                 putBoolean(PrefKeys.RELAY_AGGREGATOR_WIFI_ONLY, settings.relayAggregatorWifiOnly)
+                putBoolean(PrefKeys.RELAY_AGGREGATOR_AUTH_ENABLED, settings.relayAggregatorAuthEnabled)
+                putString(PrefKeys.AGGREGATOR_SIGNER_PUBKEY, settings.aggregatorSignerPubkey)
+                putString(PrefKeys.AGGREGATOR_SIGNER_PACKAGE_NAME, settings.aggregatorSignerPackageName)
             }
         }
     }
@@ -155,5 +161,8 @@ object LocalPreferences {
         Settings.relayAggregatorLastSync = prefs.getLong(PrefKeys.RELAY_AGGREGATOR_LAST_SYNC, 0L)
         Settings.relayAggregatorExtraRelays = prefs.getStringSet(PrefKeys.RELAY_AGGREGATOR_EXTRA_RELAYS, emptySet()) ?: emptySet()
         Settings.relayAggregatorWifiOnly = prefs.getBoolean(PrefKeys.RELAY_AGGREGATOR_WIFI_ONLY, true)
+        Settings.relayAggregatorAuthEnabled = prefs.getBoolean(PrefKeys.RELAY_AGGREGATOR_AUTH_ENABLED, false)
+        Settings.aggregatorSignerPubkey = prefs.getString(PrefKeys.AGGREGATOR_SIGNER_PUBKEY, "") ?: ""
+        Settings.aggregatorSignerPackageName = prefs.getString(PrefKeys.AGGREGATOR_SIGNER_PACKAGE_NAME, "") ?: ""
     }
 }

--- a/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
@@ -42,7 +42,6 @@ object PrefKeys {
     const val RELAY_AGGREGATOR_LAST_SYNC = "relay_aggregator_last_sync"
     const val RELAY_AGGREGATOR_EXTRA_RELAYS = "relay_aggregator_extra_relays"
     const val RELAY_AGGREGATOR_WIFI_ONLY = "relay_aggregator_wifi_only"
-    const val RELAY_AGGREGATOR_AUTH_ENABLED = "relay_aggregator_auth_enabled"
     const val AGGREGATOR_SIGNER_PUBKEY = "aggregator_signer_pubkey"
     const val AGGREGATOR_SIGNER_PACKAGE_NAME = "aggregator_signer_package_name"
 }
@@ -106,7 +105,6 @@ object LocalPreferences {
                 putLong(PrefKeys.RELAY_AGGREGATOR_LAST_SYNC, settings.relayAggregatorLastSync)
                 putStringSet(PrefKeys.RELAY_AGGREGATOR_EXTRA_RELAYS, settings.relayAggregatorExtraRelays)
                 putBoolean(PrefKeys.RELAY_AGGREGATOR_WIFI_ONLY, settings.relayAggregatorWifiOnly)
-                putBoolean(PrefKeys.RELAY_AGGREGATOR_AUTH_ENABLED, settings.relayAggregatorAuthEnabled)
                 putString(PrefKeys.AGGREGATOR_SIGNER_PUBKEY, settings.aggregatorSignerPubkey)
                 putString(PrefKeys.AGGREGATOR_SIGNER_PACKAGE_NAME, settings.aggregatorSignerPackageName)
             }
@@ -161,7 +159,6 @@ object LocalPreferences {
         Settings.relayAggregatorLastSync = prefs.getLong(PrefKeys.RELAY_AGGREGATOR_LAST_SYNC, 0L)
         Settings.relayAggregatorExtraRelays = prefs.getStringSet(PrefKeys.RELAY_AGGREGATOR_EXTRA_RELAYS, emptySet()) ?: emptySet()
         Settings.relayAggregatorWifiOnly = prefs.getBoolean(PrefKeys.RELAY_AGGREGATOR_WIFI_ONLY, true)
-        Settings.relayAggregatorAuthEnabled = prefs.getBoolean(PrefKeys.RELAY_AGGREGATOR_AUTH_ENABLED, false)
         Settings.aggregatorSignerPubkey = prefs.getString(PrefKeys.AGGREGATOR_SIGNER_PUBKEY, "") ?: ""
         Settings.aggregatorSignerPackageName = prefs.getString(PrefKeys.AGGREGATOR_SIGNER_PACKAGE_NAME, "") ?: ""
     }

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -1,6 +1,7 @@
 package com.greenart7c3.citrine.service
 
 import android.content.Context
+import android.content.Intent
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
@@ -168,6 +169,11 @@ object RelayAggregator {
     // the authenticator's lifespan to the aggregator's scope; it stops listening on cancel.
     @Volatile private var authenticator: RelayAuthenticator? = null
 
+    // External signer used by the authenticator. Held so [deliverSignerResponse] can route
+    // an Intent result received by MainActivity into the same instance whose suspended
+    // sign() call is awaiting it.
+    @Volatile private var relayAuthSigner: NostrSignerExternal? = null
+
     // Debounced re-evaluation of network state. Cancelled and rescheduled by every
     // ConnectivityManager callback so a burst of changes only triggers one evaluation.
     @Volatile private var networkEvalJob: Job? = null
@@ -314,6 +320,7 @@ object RelayAggregator {
         // the aggregator. Drop the reference here so a subsequent start() recreates it
         // against the new scope rather than reusing the dead one.
         authenticator = null
+        relayAuthSigner = null
 
         unregisterNetworkCallback()
 
@@ -353,6 +360,13 @@ object RelayAggregator {
      * Re-entrant: drops a previously installed authenticator before installing a new one.
      * No-op when the signer pubkey/packageName is missing — relays that send AUTH challenges
      * will simply not get a response, which matches the prior behavior.
+     *
+     * The signer is configured with both the ContentResolver (background signing path, used
+     * when Amber has stored an auto-approve for kind 22242) and a foreground intent launcher
+     * (fallback that pops the Amber UI from the application context when no auto-approve is
+     * available). Without the foreground launcher, sign() throws
+     * `RunningOnBackgroundWithoutAutomaticPermissionException` the first time Amber needs
+     * manual approval.
      */
     private fun installAuthenticatorIfNeeded(scope: CoroutineScope) {
         val pubkey = Settings.aggregatorSignerPubkey
@@ -362,6 +376,20 @@ object RelayAggregator {
             return
         }
         val signer = NostrSignerExternal(pubkey, pkg, Citrine.instance.contentResolver)
+        // Allow the signer to fall back to Amber's UI when the background ContentResolver
+        // path can't auto-approve. We're running in a Service, so the launched intent must
+        // carry FLAG_ACTIVITY_NEW_TASK to start from the application context. The signer's
+        // response Intent is delivered back via MainActivity.onNewIntent → relayAuthSigner
+        // forwarding when the user finishes the Amber flow.
+        signer.registerForegroundLauncher { intent ->
+            try {
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                Citrine.instance.startActivity(intent)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to launch signer intent from application context", e)
+            }
+        }
+        relayAuthSigner = signer
         Log.d(TAG, "Installing RelayAuthenticator for $pubkey via $pkg")
         authenticator = RelayAuthenticator(Citrine.instance.client, scope) { template ->
             try {
@@ -374,6 +402,15 @@ object RelayAggregator {
                 emptyList()
             }
         }
+    }
+
+    /**
+     * Forward a signer response Intent received by an Activity (e.g. MainActivity.onNewIntent)
+     * to the relay-auth signer so the suspended sign() call resumes. Safe to call when no
+     * signer is currently installed — the response is just dropped.
+     */
+    fun deliverSignerResponse(data: Intent) {
+        relayAuthSigner?.newResponse(data)
     }
 
     private fun connectivityManager(): ConnectivityManager? = Citrine.instance.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -349,21 +349,15 @@ object RelayAggregator {
     }
 
     /**
-     * Construct a [RelayAuthenticator] bound to [scope] when the user has enabled NIP-42 AUTH
-     * for the aggregator and a signer identity is configured. Re-entrant: drops a previously
-     * installed authenticator before installing a new one. No-op when AUTH is disabled or
-     * the signer pubkey/packageName is missing — relays that send AUTH challenges will
-     * simply not get a response, which matches the prior behavior.
+     * Construct a [RelayAuthenticator] bound to [scope] when a signer identity is configured.
+     * Re-entrant: drops a previously installed authenticator before installing a new one.
+     * No-op when the signer pubkey/packageName is missing — relays that send AUTH challenges
+     * will simply not get a response, which matches the prior behavior.
      */
     private fun installAuthenticatorIfNeeded(scope: CoroutineScope) {
-        if (!Settings.relayAggregatorAuthEnabled) {
-            authenticator = null
-            return
-        }
         val pubkey = Settings.aggregatorSignerPubkey
         val pkg = Settings.aggregatorSignerPackageName
         if (pubkey.isBlank() || pkg.isBlank()) {
-            Log.d(TAG, "AUTH enabled but signer pubkey/packageName missing; skipping authenticator install")
             authenticator = null
             return
         }

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -26,6 +26,7 @@ import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
 import com.vitorpamplona.quartz.nip02FollowList.ContactListEvent
+import com.vitorpamplona.quartz.nip42RelayAuth.RelayAuthEvent
 import com.vitorpamplona.quartz.nip55AndroidSigner.client.NostrSignerExternal
 import com.vitorpamplona.quartz.nip65RelayList.AdvertisedRelayListEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
@@ -181,6 +182,11 @@ object RelayAggregator {
     // in-flight AUTH state.
     @Volatile private var installedAuthIdentity: Pair<String, String>? = null
 
+    // Cache of (relay → last challenge string, signed AUTH event) so a relay re-sending
+    // the same challenge — common on reconnect, and what was driving the duplicate Amber
+    // prompts — returns the previously-signed event without re-invoking the signer.
+    private val signedAuthCache: ConcurrentHashMap<String, Pair<String, RelayAuthEvent>> = ConcurrentHashMap()
+
     // Debounced re-evaluation of network state. Cancelled and rescheduled by every
     // ConnectivityManager callback so a burst of changes only triggers one evaluation.
     @Volatile private var networkEvalJob: Job? = null
@@ -331,6 +337,7 @@ object RelayAggregator {
         authenticator = null
         relayAuthSigner = null
         installedAuthIdentity = null
+        signedAuthCache.clear()
 
         unregisterNetworkCallback()
 
@@ -428,10 +435,23 @@ object RelayAggregator {
         }
         relayAuthSigner = signer
         installedAuthIdentity = desired
+        signedAuthCache.clear()
         Log.d(TAG, "Installing RelayAuthenticator for $pubkey via $pkg")
         authenticator = RelayAuthenticator(Citrine.instance.client, scope) { template ->
+            val relay = template.tags.firstOrNull { it.size > 1 && it[0] == "relay" }?.get(1)
+            val challenge = template.tags.firstOrNull { it.size > 1 && it[0] == "challenge" }?.get(1)
+            if (relay != null && challenge != null) {
+                val cached = signedAuthCache[relay]
+                if (cached != null && cached.first == challenge) {
+                    Log.d(TAG, "Reusing cached AUTH for $relay (challenge unchanged)")
+                    return@RelayAuthenticator listOf(cached.second)
+                }
+            }
             try {
                 val signed = signer.sign(template)
+                if (relay != null && challenge != null) {
+                    signedAuthCache[relay] = challenge to signed
+                }
                 listOf(signed)
             } catch (e: CancellationException) {
                 throw e

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -174,6 +174,13 @@ object RelayAggregator {
     // sign() call is awaiting it.
     @Volatile private var relayAuthSigner: NostrSignerExternal? = null
 
+    // Identity (pubkey + packageName) of the signer the currently-installed authenticator
+    // was built for. Used by installAuthenticatorIfNeeded to skip a rebuild when the
+    // signer hasn't changed — every onConfigChanged call would otherwise tear down and
+    // recreate the authenticator, briefly leaving zero listeners and discarding any
+    // in-flight AUTH state.
+    @Volatile private var installedAuthIdentity: Pair<String, String>? = null
+
     // Debounced re-evaluation of network state. Cancelled and rescheduled by every
     // ConnectivityManager callback so a burst of changes only triggers one evaluation.
     @Volatile private var networkEvalJob: Job? = null
@@ -316,11 +323,14 @@ object RelayAggregator {
         listener?.let { Citrine.instance.client.removeConnectionListener(it) }
         listener = null
 
-        // The RelayAuthenticator listens via the cancelled scope, so its coroutines die with
-        // the aggregator. Drop the reference here so a subsequent start() recreates it
-        // against the new scope rather than reusing the dead one.
+        // The authenticator's internal client listener stays registered with NostrClient
+        // until destroy() is called, so explicitly tear it down here in addition to
+        // dropping the references. A subsequent start() will install a fresh one against
+        // the new scope.
+        authenticator?.destroy()
         authenticator = null
         relayAuthSigner = null
+        installedAuthIdentity = null
 
         unregisterNetworkCallback()
 
@@ -371,10 +381,24 @@ object RelayAggregator {
     private fun installAuthenticatorIfNeeded(scope: CoroutineScope) {
         val pubkey = Settings.aggregatorSignerPubkey
         val pkg = Settings.aggregatorSignerPackageName
-        if (pubkey.isBlank() || pkg.isBlank()) {
-            authenticator = null
-            return
-        }
+
+        // Skip the tear-down/rebuild if the signer identity matches what we already have
+        // installed. onConfigChanged fires for every settings tweak (kind add, refresh
+        // interval, etc.); without this guard each one would briefly leave the relay
+        // unprotected and discard in-flight AUTH state.
+        val desired = if (pubkey.isBlank() || pkg.isBlank()) null else (pubkey to pkg)
+        if (authenticator != null && installedAuthIdentity == desired) return
+
+        // Always tear down the previous authenticator before installing a new one — its
+        // internal client listener stays registered with NostrClient until destroy() runs,
+        // and a second authenticator with the same listener would answer the same AUTH
+        // challenge twice.
+        authenticator?.destroy()
+        authenticator = null
+        relayAuthSigner = null
+        installedAuthIdentity = null
+
+        if (desired == null) return
         val signer = NostrSignerExternal(pubkey, pkg, Citrine.instance.contentResolver)
         // Allow the signer to fall back to Amber's UI when the background ContentResolver
         // path can't auto-approve. We're running in a Service, so the launched intent must
@@ -403,6 +427,7 @@ object RelayAggregator {
             }
         }
         relayAuthSigner = signer
+        installedAuthIdentity = desired
         Log.d(TAG, "Installing RelayAuthenticator for $pubkey via $pkg")
         authenticator = RelayAuthenticator(Citrine.instance.client, scope) { template ->
             try {

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -383,7 +383,13 @@ object RelayAggregator {
         // forwarding when the user finishes the Amber flow.
         signer.registerForegroundLauncher { intent ->
             try {
-                intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                // SINGLE_TOP|CLEAR_TOP are required by Amber; NEW_TASK is required to start
+                // an Activity from a non-Activity (Application) context.
+                intent.addFlags(
+                    Intent.FLAG_ACTIVITY_SINGLE_TOP or
+                        Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                        Intent.FLAG_ACTIVITY_NEW_TASK,
+                )
                 Citrine.instance.startActivity(intent)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to launch signer intent from application context", e)

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -382,17 +382,24 @@ object RelayAggregator {
         // response Intent is delivered back via MainActivity.onNewIntent → relayAuthSigner
         // forwarding when the user finishes the Amber flow.
         signer.registerForegroundLauncher { intent ->
+            // Amber requires the caller's UID to be set on the intent so it can identify
+            // which app is asking and round-trip setResult back. FLAG_ACTIVITY_NEW_TASK
+            // (the obvious way to start an Activity from a Service) nulls that UID, so
+            // we must launch from a real foreground Activity. When Citrine has no Activity
+            // in front (background-only service), the foreground path can't run — the
+            // user has to open the app once so the Activity callback registers, then the
+            // next AUTH challenge will succeed (or rely on Amber's pre-approved
+            // ContentResolver path for fully background signing).
+            val activity = Citrine.instance.currentActivity
+            if (activity == null) {
+                Log.w(TAG, "No foreground Activity to launch signer intent; open Citrine once to authorize")
+                return@registerForegroundLauncher
+            }
             try {
-                // SINGLE_TOP|CLEAR_TOP are required by Amber; NEW_TASK is required to start
-                // an Activity from a non-Activity (Application) context.
-                intent.addFlags(
-                    Intent.FLAG_ACTIVITY_SINGLE_TOP or
-                        Intent.FLAG_ACTIVITY_CLEAR_TOP or
-                        Intent.FLAG_ACTIVITY_NEW_TASK,
-                )
-                Citrine.instance.startActivity(intent)
+                intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                activity.startActivity(intent)
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to launch signer intent from application context", e)
+                Log.e(TAG, "Failed to launch signer intent from Activity context", e)
             }
         }
         relayAuthSigner = signer

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -14,6 +14,7 @@ import com.greenart7c3.citrine.server.Settings
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.fetchFirst
+import com.vitorpamplona.quartz.nip01Core.relay.client.auth.RelayAuthenticator
 import com.vitorpamplona.quartz.nip01Core.relay.client.listeners.RelayConnectionListener
 import com.vitorpamplona.quartz.nip01Core.relay.client.single.IRelayClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.single.newSubId
@@ -24,6 +25,7 @@ import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
 import com.vitorpamplona.quartz.nip02FollowList.ContactListEvent
+import com.vitorpamplona.quartz.nip55AndroidSigner.client.NostrSignerExternal
 import com.vitorpamplona.quartz.nip65RelayList.AdvertisedRelayListEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 import java.util.concurrent.ConcurrentHashMap
@@ -161,6 +163,11 @@ object RelayAggregator {
 
     @Volatile private var networkCallback: ConnectivityManager.NetworkCallback? = null
 
+    // RelayAuthenticator listens for NIP-42 AUTH challenges from upstream relays and signs
+    // a kind-22242 event using the external signer. Held so the start/stop lifecycle ties
+    // the authenticator's lifespan to the aggregator's scope; it stops listening on cancel.
+    @Volatile private var authenticator: RelayAuthenticator? = null
+
     // Debounced re-evaluation of network state. Cancelled and rescheduled by every
     // ConnectivityManager callback so a burst of changes only triggers one evaluation.
     @Volatile private var networkEvalJob: Job? = null
@@ -253,6 +260,8 @@ object RelayAggregator {
         listener = newListener
         Citrine.instance.client.addConnectionListener(newListener)
 
+        installAuthenticatorIfNeeded(newScope)
+
         registerNetworkCallback()
         // Initial check: if we're already on a metered network and the user wants
         // wifi-only, start in the paused state instead of opening subs.
@@ -301,6 +310,11 @@ object RelayAggregator {
         listener?.let { Citrine.instance.client.removeConnectionListener(it) }
         listener = null
 
+        // The RelayAuthenticator listens via the cancelled scope, so its coroutines die with
+        // the aggregator. Drop the reference here so a subsequent start() recreates it
+        // against the new scope rather than reusing the dead one.
+        authenticator = null
+
         unregisterNetworkCallback()
 
         trackedSubIds.forEach {
@@ -332,6 +346,40 @@ object RelayAggregator {
         s.cancel()
 
         _status.value = AggregatorStatus(enabled = false, phase = AggregatorPhase.IDLE)
+    }
+
+    /**
+     * Construct a [RelayAuthenticator] bound to [scope] when the user has enabled NIP-42 AUTH
+     * for the aggregator and a signer identity is configured. Re-entrant: drops a previously
+     * installed authenticator before installing a new one. No-op when AUTH is disabled or
+     * the signer pubkey/packageName is missing — relays that send AUTH challenges will
+     * simply not get a response, which matches the prior behavior.
+     */
+    private fun installAuthenticatorIfNeeded(scope: CoroutineScope) {
+        if (!Settings.relayAggregatorAuthEnabled) {
+            authenticator = null
+            return
+        }
+        val pubkey = Settings.aggregatorSignerPubkey
+        val pkg = Settings.aggregatorSignerPackageName
+        if (pubkey.isBlank() || pkg.isBlank()) {
+            Log.d(TAG, "AUTH enabled but signer pubkey/packageName missing; skipping authenticator install")
+            authenticator = null
+            return
+        }
+        val signer = NostrSignerExternal(pubkey, pkg, Citrine.instance.contentResolver)
+        Log.d(TAG, "Installing RelayAuthenticator for $pubkey via $pkg")
+        authenticator = RelayAuthenticator(Citrine.instance.client, scope) { template ->
+            try {
+                val signed = signer.sign(template)
+                listOf(signed)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to sign AUTH challenge", e)
+                emptyList()
+            }
+        }
     }
 
     private fun connectivityManager(): ConnectivityManager? = Citrine.instance.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
@@ -452,6 +500,10 @@ object RelayAggregator {
                 start(database)
             }
             enabled && running -> {
+                // The AUTH toggle / signer identity may have changed. Reinstall the
+                // authenticator against the running scope so the new settings take effect
+                // without a full restart.
+                scope?.let { installAuthenticatorIfNeeded(it) }
                 // The wifi-only toggle may have just changed; re-evaluate before
                 // dispatching a refresh so a flip to "pause on metered" doesn't kick
                 // off a doomed refresh that we'd immediately tear down.

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -445,6 +445,7 @@ object RelayAggregator {
                 return@registerForegroundLauncher
             }
             try {
+                intent.`package` = pkg
                 intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 launcher(intent)
             } catch (e: Exception) {

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -426,11 +426,11 @@ object RelayAggregator {
 
         if (desired == null) return
         val signer = NostrSignerExternal(pubkey, pkg, Citrine.instance.contentResolver)
-        // Allow the signer to fall back to Amber's UI when the background ContentResolver
-        // path can't auto-approve. We're running in a Service, so the launched intent must
-        // carry FLAG_ACTIVITY_NEW_TASK to start from the application context. The signer's
-        // response Intent is delivered back via MainActivity.onNewIntent → relayAuthSigner
-        // forwarding when the user finishes the Amber flow.
+        // Lets the signer fall back to Amber's UI when the background ContentResolver path
+        // can't auto-approve. The launcher routes through MainActivity's
+        // ActivityResultLauncher (set via [registerActivityLauncher]), which preserves
+        // callingPackage on the intent and feeds Amber's reply back into this signer via
+        // [deliverSignerResponse] so the suspended sign() resumes.
         signer.registerForegroundLauncher { intent ->
             // Must go through the ActivityResultLauncher MainActivity registered with us —
             // that's what populates Intent.callingPackage so Amber can authenticate the

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -187,6 +187,25 @@ object RelayAggregator {
     // prompts — returns the previously-signed event without re-invoking the signer.
     private val signedAuthCache: ConcurrentHashMap<String, Pair<String, RelayAuthEvent>> = ConcurrentHashMap()
 
+    // Activity-scoped Intent launcher set by MainActivity. Uses registerForActivityResult
+    // under the hood, which preserves the caller's identity on the intent — Amber relies
+    // on that callingPackage to identify which app is asking, and a plain Application-
+    // context startActivity() makes it null.
+    @Volatile private var activityLauncher: ((Intent) -> Unit)? = null
+
+    /**
+     * Called by [MainActivity] in onCreate to provide an ActivityResultLauncher-backed
+     * way to launch the signer intent. The aggregator's foreground signer path goes
+     * through this when invoked while the activity is alive.
+     */
+    fun registerActivityLauncher(launcher: (Intent) -> Unit) {
+        activityLauncher = launcher
+    }
+
+    fun unregisterActivityLauncher() {
+        activityLauncher = null
+    }
+
     // Debounced re-evaluation of network state. Cancelled and rescheduled by every
     // ConnectivityManager callback so a burst of changes only triggers one evaluation.
     @Volatile private var networkEvalJob: Job? = null
@@ -413,24 +432,23 @@ object RelayAggregator {
         // response Intent is delivered back via MainActivity.onNewIntent → relayAuthSigner
         // forwarding when the user finishes the Amber flow.
         signer.registerForegroundLauncher { intent ->
-            // Amber requires the caller's UID to be set on the intent so it can identify
-            // which app is asking and round-trip setResult back. FLAG_ACTIVITY_NEW_TASK
-            // (the obvious way to start an Activity from a Service) nulls that UID, so
-            // we must launch from a real foreground Activity. When Citrine has no Activity
-            // in front (background-only service), the foreground path can't run — the
-            // user has to open the app once so the Activity callback registers, then the
-            // next AUTH challenge will succeed (or rely on Amber's pre-approved
-            // ContentResolver path for fully background signing).
-            val activity = Citrine.instance.currentActivity
-            if (activity == null) {
-                Log.w(TAG, "No foreground Activity to launch signer intent; open Citrine once to authorize")
+            // Must go through the ActivityResultLauncher MainActivity registered with us —
+            // that's what populates Intent.callingPackage so Amber can authenticate the
+            // caller. A bare activity.startActivity() leaves callingPackage null and
+            // Amber rejects. When MainActivity isn't alive, the foreground path can't
+            // run; the user must open Citrine once so onCreate registers the launcher,
+            // and from then on the ContentResolver background path also works thanks to
+            // Amber's stored auto-approve.
+            val launcher = activityLauncher
+            if (launcher == null) {
+                Log.w(TAG, "No Activity launcher registered; open Citrine once to authorize the signer")
                 return@registerForegroundLauncher
             }
             try {
                 intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                activity.startActivity(intent)
+                launcher(intent)
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to launch signer intent from Activity context", e)
+                Log.e(TAG, "Failed to launch signer intent via Activity launcher", e)
             }
         }
         relayAuthSigner = signer

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -383,7 +383,7 @@ object RelayAggregator {
         // forwarding when the user finishes the Amber flow.
         signer.registerForegroundLauncher { intent ->
             try {
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 Citrine.instance.startActivity(intent)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to launch signer intent from application context", e)

--- a/app/src/main/java/com/greenart7c3/citrine/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/SettingsScreen.kt
@@ -22,8 +22,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Key
 import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
@@ -154,8 +158,14 @@ fun SettingsScreen(
                             key
                         }
                         if (returnedKey.isBlank() || packageName.isBlank()) return@let
+                        // The pubkey field is the aggregator's identity — populate it
+                        // from the signer's reply so a fresh login is enough to start the
+                        // aggregator. Storing the packageName too lets RelayAggregator
+                        // reconstruct a NostrSignerExternal for AUTH challenges.
+                        Settings.aggregatorPubkey = returnedKey
                         Settings.aggregatorSignerPubkey = returnedKey
                         Settings.aggregatorSignerPackageName = packageName
+                        aggregatorPubkey = TextFieldValue(returnedKey)
                         aggregatorSignerPubkey = returnedKey
                         aggregatorSignerPackageName = packageName
                         LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
@@ -564,6 +574,14 @@ fun SettingsScreen(
                         val text = newValue.text.trim()
                         if (text.isBlank()) {
                             Settings.aggregatorPubkey = ""
+                            // A manually cleared pubkey invalidates any previously-stored
+                            // signer identity — they were tied to the pubkey that was just
+                            // removed, and the packageName alone can't sign for a different
+                            // user.
+                            Settings.aggregatorSignerPubkey = ""
+                            Settings.aggregatorSignerPackageName = ""
+                            aggregatorSignerPubkey = ""
+                            aggregatorSignerPackageName = ""
                             LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
                             RelayAggregator.onConfigChanged(AppDatabase.getDatabase(context))
                             return@OutlinedTextField
@@ -573,10 +591,50 @@ fun SettingsScreen(
                             return@OutlinedTextField
                         }
                         Settings.aggregatorPubkey = key
+                        // Manually editing the pubkey to something other than the
+                        // signed-in identity clears the AUTH signer — Amber can only
+                        // sign for the pubkey it actually controls.
+                        if (key != Settings.aggregatorSignerPubkey) {
+                            Settings.aggregatorSignerPubkey = ""
+                            Settings.aggregatorSignerPackageName = ""
+                            aggregatorSignerPubkey = ""
+                            aggregatorSignerPackageName = ""
+                        }
                         LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
                         RelayAggregator.onConfigChanged(AppDatabase.getDatabase(context))
                     },
                     singleLine = true,
+                    trailingIcon = {
+                        IconButton(
+                            onClick = {
+                                try {
+                                    val intent = Intent(Intent.ACTION_VIEW, "nostrsigner:".toUri())
+                                    intent.putExtra("type", "get_public_key")
+                                    val permission = com.vitorpamplona.quartz.nip55AndroidSigner.api.permission.Permission(
+                                        com.vitorpamplona.quartz.nip55AndroidSigner.api.CommandType.SIGN_EVENT,
+                                        22242,
+                                    )
+                                    intent.putExtra("permissions", "[${permission.toJson()}]")
+                                    intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                                    aggregatorSignerLauncher.launch(intent)
+                                } catch (e: Exception) {
+                                    android.util.Log.d(Citrine.TAG, e.message ?: "", e)
+                                    Toast.makeText(
+                                        context,
+                                        context.getString(R.string.no_external_signer_installed),
+                                        Toast.LENGTH_SHORT,
+                                    ).show()
+                                    val fallback = Intent(Intent.ACTION_VIEW, "https://github.com/greenart7c3/Amber/releases".toUri())
+                                    aggregatorSignerLauncher.launch(fallback)
+                                }
+                            },
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Key,
+                                contentDescription = stringResource(R.string.relay_aggregator_signer_login),
+                            )
+                        }
+                    },
                 )
             }
             item {
@@ -732,77 +790,6 @@ fun SettingsScreen(
                         RelayAggregator.onConfigChanged(AppDatabase.getDatabase(context))
                     },
                 )
-            }
-
-            item {
-                Text(
-                    text = stringResource(R.string.relay_aggregator_signer),
-                    style = MaterialTheme.typography.titleSmall,
-                    modifier = Modifier.padding(top = 12.dp),
-                )
-            }
-            item {
-                val loggedInLabel = if (aggregatorSignerPubkey.isNotBlank()) {
-                    stringResource(R.string.relay_aggregator_signer_logged_in_as, aggregatorSignerPubkey.take(16) + "…")
-                } else {
-                    stringResource(R.string.relay_aggregator_signer_not_logged_in)
-                }
-                Text(
-                    text = loggedInLabel,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(bottom = 4.dp),
-                )
-            }
-            item {
-                ElevatedButton(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 4.dp),
-                    onClick = {
-                        try {
-                            val intent = Intent(Intent.ACTION_VIEW, "nostrsigner:".toUri())
-                            intent.putExtra("type", "get_public_key")
-                            val permission = com.vitorpamplona.quartz.nip55AndroidSigner.api.permission.Permission(
-                                com.vitorpamplona.quartz.nip55AndroidSigner.api.CommandType.SIGN_EVENT,
-                                22242,
-                            )
-                            intent.putExtra("permissions", "[${permission.toJson()}]")
-                            intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                            aggregatorSignerLauncher.launch(intent)
-                        } catch (e: Exception) {
-                            android.util.Log.d(Citrine.TAG, e.message ?: "", e)
-                            Toast.makeText(
-                                context,
-                                context.getString(R.string.no_external_signer_installed),
-                                Toast.LENGTH_SHORT,
-                            ).show()
-                            val fallback = Intent(Intent.ACTION_VIEW, "https://github.com/greenart7c3/Amber/releases".toUri())
-                            aggregatorSignerLauncher.launch(fallback)
-                        }
-                    },
-                ) {
-                    Text(stringResource(R.string.relay_aggregator_signer_login))
-                }
-            }
-            if (aggregatorSignerPubkey.isNotBlank()) {
-                item {
-                    ElevatedButton(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 4.dp),
-                        onClick = {
-                            Settings.aggregatorSignerPubkey = ""
-                            Settings.aggregatorSignerPackageName = ""
-                            aggregatorSignerPubkey = ""
-                            aggregatorSignerPackageName = ""
-                            LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
-                            RelayAggregator.onConfigChanged(AppDatabase.getDatabase(context))
-                        },
-                    ) {
-                        Text(stringResource(R.string.relay_aggregator_signer_logout))
-                    }
-                }
             }
 
             // ── Others ─────────────────────────────────────────────────────────

--- a/app/src/main/java/com/greenart7c3/citrine/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/SettingsScreen.kt
@@ -7,6 +7,8 @@ import android.net.InetAddresses.isNumericAddress
 import android.os.Build
 import android.util.Patterns
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -126,6 +128,45 @@ fun SettingsScreen(
         var aggregatorWifiOnly by remember { mutableStateOf(Settings.relayAggregatorWifiOnly) }
         var aggregatorExtraRelays by remember { mutableStateOf(Settings.relayAggregatorExtraRelays) }
         var aggregatorExtraRelayInput by remember { mutableStateOf(TextFieldValue("")) }
+        var aggregatorAuthEnabled by remember { mutableStateOf(Settings.relayAggregatorAuthEnabled) }
+        var aggregatorSignerPubkey by remember { mutableStateOf(Settings.aggregatorSignerPubkey) }
+        var aggregatorSignerPackageName by remember { mutableStateOf(Settings.aggregatorSignerPackageName) }
+
+        val aggregatorSignerLauncher = rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.StartActivityForResult(),
+        ) { result ->
+            if (result.resultCode != android.app.Activity.RESULT_OK) {
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.sign_request_rejected),
+                    Toast.LENGTH_SHORT,
+                ).show()
+            } else {
+                result.data?.let {
+                    try {
+                        val key = it.getStringExtra("signature") ?: ""
+                        val packageName = it.getStringExtra("package") ?: ""
+                        val returnedKey = if (key.startsWith("npub")) {
+                            when (val parsed = Nip19Parser.uriToRoute(key)?.entity) {
+                                is NPub -> parsed.hex
+                                else -> ""
+                            }
+                        } else {
+                            key
+                        }
+                        if (returnedKey.isBlank() || packageName.isBlank()) return@let
+                        Settings.aggregatorSignerPubkey = returnedKey
+                        Settings.aggregatorSignerPackageName = packageName
+                        aggregatorSignerPubkey = returnedKey
+                        aggregatorSignerPackageName = packageName
+                        LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                        RelayAggregator.onConfigChanged(AppDatabase.getDatabase(context))
+                    } catch (e: Exception) {
+                        android.util.Log.d(Citrine.TAG, e.message ?: "", e)
+                    }
+                }
+            }
+        }
 
         var shouldAddWebClient = false
         var webPath by remember { mutableStateOf(TextFieldValue("")) }
@@ -688,6 +729,102 @@ fun SettingsScreen(
                         val relays = Settings.relayAggregatorExtraRelays.toMutableSet().apply { remove(relay) }
                         Settings.relayAggregatorExtraRelays = relays
                         aggregatorExtraRelays = relays
+                        LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                        RelayAggregator.onConfigChanged(AppDatabase.getDatabase(context))
+                    },
+                )
+            }
+
+            item {
+                Text(
+                    text = stringResource(R.string.relay_aggregator_signer),
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(top = 12.dp),
+                )
+            }
+            item {
+                val loggedInLabel = if (aggregatorSignerPubkey.isNotBlank()) {
+                    stringResource(R.string.relay_aggregator_signer_logged_in_as, aggregatorSignerPubkey.take(16) + "…")
+                } else {
+                    stringResource(R.string.relay_aggregator_signer_not_logged_in)
+                }
+                Text(
+                    text = loggedInLabel,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = 4.dp),
+                )
+            }
+            item {
+                ElevatedButton(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp),
+                    onClick = {
+                        try {
+                            val intent = Intent(Intent.ACTION_VIEW, "nostrsigner:".toUri())
+                            intent.putExtra("type", "get_public_key")
+                            val permission = com.vitorpamplona.quartz.nip55AndroidSigner.api.permission.Permission(
+                                com.vitorpamplona.quartz.nip55AndroidSigner.api.CommandType.SIGN_EVENT,
+                                22242,
+                            )
+                            intent.putExtra("permissions", "[${permission.toJson()}]")
+                            intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                            aggregatorSignerLauncher.launch(intent)
+                        } catch (e: Exception) {
+                            android.util.Log.d(Citrine.TAG, e.message ?: "", e)
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.no_external_signer_installed),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                            val fallback = Intent(Intent.ACTION_VIEW, "https://github.com/greenart7c3/Amber/releases".toUri())
+                            aggregatorSignerLauncher.launch(fallback)
+                        }
+                    },
+                ) {
+                    Text(stringResource(R.string.relay_aggregator_signer_login))
+                }
+            }
+            if (aggregatorSignerPubkey.isNotBlank()) {
+                item {
+                    ElevatedButton(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        onClick = {
+                            // Logging out also disables AUTH so the aggregator doesn't fail
+                            // to sign challenges on the next refresh.
+                            Settings.aggregatorSignerPubkey = ""
+                            Settings.aggregatorSignerPackageName = ""
+                            Settings.relayAggregatorAuthEnabled = false
+                            aggregatorSignerPubkey = ""
+                            aggregatorSignerPackageName = ""
+                            aggregatorAuthEnabled = false
+                            LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
+                            RelayAggregator.onConfigChanged(AppDatabase.getDatabase(context))
+                        },
+                    ) {
+                        Text(stringResource(R.string.relay_aggregator_signer_logout))
+                    }
+                }
+            }
+            item {
+                SwitchSettingRow(
+                    title = stringResource(R.string.relay_aggregator_auth_enabled),
+                    description = stringResource(R.string.relay_aggregator_auth_enabled_description),
+                    checked = aggregatorAuthEnabled,
+                    onCheckedChange = { newValue ->
+                        if (newValue && Settings.aggregatorSignerPubkey.isBlank()) {
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.relay_aggregator_auth_signer_required),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                            return@SwitchSettingRow
+                        }
+                        aggregatorAuthEnabled = newValue
+                        Settings.relayAggregatorAuthEnabled = newValue
                         LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
                         RelayAggregator.onConfigChanged(AppDatabase.getDatabase(context))
                     },

--- a/app/src/main/java/com/greenart7c3/citrine/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/SettingsScreen.kt
@@ -128,7 +128,6 @@ fun SettingsScreen(
         var aggregatorWifiOnly by remember { mutableStateOf(Settings.relayAggregatorWifiOnly) }
         var aggregatorExtraRelays by remember { mutableStateOf(Settings.relayAggregatorExtraRelays) }
         var aggregatorExtraRelayInput by remember { mutableStateOf(TextFieldValue("")) }
-        var aggregatorAuthEnabled by remember { mutableStateOf(Settings.relayAggregatorAuthEnabled) }
         var aggregatorSignerPubkey by remember { mutableStateOf(Settings.aggregatorSignerPubkey) }
         var aggregatorSignerPackageName by remember { mutableStateOf(Settings.aggregatorSignerPackageName) }
 
@@ -793,14 +792,10 @@ fun SettingsScreen(
                             .fillMaxWidth()
                             .padding(vertical = 4.dp),
                         onClick = {
-                            // Logging out also disables AUTH so the aggregator doesn't fail
-                            // to sign challenges on the next refresh.
                             Settings.aggregatorSignerPubkey = ""
                             Settings.aggregatorSignerPackageName = ""
-                            Settings.relayAggregatorAuthEnabled = false
                             aggregatorSignerPubkey = ""
                             aggregatorSignerPackageName = ""
-                            aggregatorAuthEnabled = false
                             LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
                             RelayAggregator.onConfigChanged(AppDatabase.getDatabase(context))
                         },
@@ -808,27 +803,6 @@ fun SettingsScreen(
                         Text(stringResource(R.string.relay_aggregator_signer_logout))
                     }
                 }
-            }
-            item {
-                SwitchSettingRow(
-                    title = stringResource(R.string.relay_aggregator_auth_enabled),
-                    description = stringResource(R.string.relay_aggregator_auth_enabled_description),
-                    checked = aggregatorAuthEnabled,
-                    onCheckedChange = { newValue ->
-                        if (newValue && Settings.aggregatorSignerPubkey.isBlank()) {
-                            Toast.makeText(
-                                context,
-                                context.getString(R.string.relay_aggregator_auth_signer_required),
-                                Toast.LENGTH_SHORT,
-                            ).show()
-                            return@SwitchSettingRow
-                        }
-                        aggregatorAuthEnabled = newValue
-                        Settings.relayAggregatorAuthEnabled = newValue
-                        LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
-                        RelayAggregator.onConfigChanged(AppDatabase.getDatabase(context))
-                    },
-                )
             }
 
             // ── Others ─────────────────────────────────────────────────────────

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,9 +151,5 @@
     <string name="relay_aggregator_events_received">%1$d events received</string>
     <string name="relay_aggregator_last_refresh">Last refresh %1$s ago</string>
     <string name="relay_aggregator_never_refreshed">No refresh yet</string>
-    <string name="relay_aggregator_signer">External signer</string>
     <string name="relay_aggregator_signer_login">Log in with external signer</string>
-    <string name="relay_aggregator_signer_logout">Sign out of external signer</string>
-    <string name="relay_aggregator_signer_logged_in_as">Logged in as %1$s</string>
-    <string name="relay_aggregator_signer_not_logged_in">Not logged in</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,4 +151,12 @@
     <string name="relay_aggregator_events_received">%1$d events received</string>
     <string name="relay_aggregator_last_refresh">Last refresh %1$s ago</string>
     <string name="relay_aggregator_never_refreshed">No refresh yet</string>
+    <string name="relay_aggregator_auth_enabled">Authenticate to upstream relays</string>
+    <string name="relay_aggregator_auth_enabled_description">Answer NIP-42 AUTH challenges from upstream relays by signing a kind 22242 event with the external signer below. Required by some relays before they will return events from their authors\' write set.</string>
+    <string name="relay_aggregator_auth_signer_required">Log in with an external signer first</string>
+    <string name="relay_aggregator_signer">External signer</string>
+    <string name="relay_aggregator_signer_login">Log in with external signer</string>
+    <string name="relay_aggregator_signer_logout">Sign out of external signer</string>
+    <string name="relay_aggregator_signer_logged_in_as">Logged in as %1$s</string>
+    <string name="relay_aggregator_signer_not_logged_in">Not logged in</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,9 +151,6 @@
     <string name="relay_aggregator_events_received">%1$d events received</string>
     <string name="relay_aggregator_last_refresh">Last refresh %1$s ago</string>
     <string name="relay_aggregator_never_refreshed">No refresh yet</string>
-    <string name="relay_aggregator_auth_enabled">Authenticate to upstream relays</string>
-    <string name="relay_aggregator_auth_enabled_description">Answer NIP-42 AUTH challenges from upstream relays by signing a kind 22242 event with the external signer below. Required by some relays before they will return events from their authors\' write set.</string>
-    <string name="relay_aggregator_auth_signer_required">Log in with an external signer first</string>
     <string name="relay_aggregator_signer">External signer</string>
     <string name="relay_aggregator_signer_login">Log in with external signer</string>
     <string name="relay_aggregator_signer_logout">Sign out of external signer</string>


### PR DESCRIPTION
## Summary
This PR adds support for NIP-42 AUTH challenges in the relay aggregator by integrating with external signers (like Amber). Users can now log in with an external signer to automatically sign authentication challenges from upstream relays.

## Key Changes

- **Settings UI Enhancement**: Added a key icon button to the aggregator pubkey field that launches an external signer (Amber) to retrieve the user's public key and signer package name
- **External Signer Integration**: Implemented `RelayAuthenticator` installation in `RelayAggregator` that automatically signs kind-22242 AUTH challenge events using the configured external signer
- **Signer Identity Management**: 
  - Store both `aggregatorSignerPubkey` and `aggregatorSignerPackageName` in settings
  - Clear signer identity when the aggregator pubkey is manually cleared or changed to a different value
  - Validate that the signer can only sign for the pubkey it controls
- **Persistence**: Added preference keys and serialization logic to save/load signer identity across app restarts
- **Lifecycle Management**: Tied the `RelayAuthenticator` lifespan to the aggregator's coroutine scope, reinstalling it when settings change without requiring a full restart

## Implementation Details

- The external signer launcher uses `ActivityResultContracts.StartActivityForResult()` to handle the signer response
- Supports both npub (Bech32) and hex format public keys from the signer
- Gracefully handles missing external signer with a fallback link to Amber releases
- The authenticator is re-entrant and can be reinstalled when the aggregator is running if signer settings change
- No-op behavior when signer identity is not configured (matches prior behavior for relays sending AUTH challenges)

https://claude.ai/code/session_01Dep4MdzcMw6a2fZGPnPLUk