### PR TITLE
Add NIP-51 mute list support to relay aggregator

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/database/EventDao.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/EventDao.kt
@@ -112,6 +112,10 @@ interface EventDao {
     @Transaction
     suspend fun getAdvertisedRelayList(pubkey: String): EventWithTags?
 
+    @Query("SELECT * FROM EventEntity WHERE pubkey = :pubkey and kind = 10000 ORDER BY createdAt DESC, id ASC LIMIT 1")
+    @Transaction
+    suspend fun getMuteList(pubkey: String): EventWithTags?
+
     @Query(
         """
         SELECT pubkey AS pubkey, MAX(createdAt) AS createdAt

--- a/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
@@ -33,7 +33,7 @@ object Settings {
 
     var relayAggregatorEnabled = false
     var aggregatorPubkey = ""
-    var relayAggregatorKinds: Set<Int> = setOf(0, 1, 3, 5, 6, 7, 1111, 10002, 30023)
+    var relayAggregatorKinds: Set<Int> = setOf(0, 1, 3, 5, 6, 7, 1111, 10000, 10002, 30023)
     var relayAggregatorRefreshMinutes = 60
     var relayAggregatorIncludeTagged = true
     var relayAggregatorLastSync: Long = 0L
@@ -83,7 +83,7 @@ object Settings {
         webClients = mutableMapOf()
         relayAggregatorEnabled = false
         aggregatorPubkey = ""
-        relayAggregatorKinds = setOf(0, 1, 3, 5, 6, 7, 1111, 10002, 30023)
+        relayAggregatorKinds = setOf(0, 1, 3, 5, 6, 7, 1111, 10000, 10002, 30023)
         relayAggregatorRefreshMinutes = 60
         relayAggregatorIncludeTagged = true
         relayAggregatorLastSync = 0L

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -6,6 +6,7 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.util.Log
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.EventDao
@@ -13,6 +14,7 @@ import com.greenart7c3.citrine.database.PubkeyTimestamp
 import com.greenart7c3.citrine.database.toEvent
 import com.greenart7c3.citrine.server.Settings
 import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.fetchFirst
 import com.vitorpamplona.quartz.nip01Core.relay.client.auth.RelayAuthenticator
@@ -146,6 +148,24 @@ object RelayAggregator {
     private val connectedRelays: MutableSet<NormalizedRelayUrl> = ConcurrentHashMap.newKeySet()
     private val eventsReceived = AtomicLong(0)
 
+    // NIP-51 (kind 10000) mute list — author pubkeys to drop and content words to drop.
+    // Words are pre-lowercased so the hot-path check can match against a single lowercase
+    // copy of the event content without per-word allocation. Both sets are swapped as a
+    // pair so a partial load never produces an inconsistent view.
+    @Volatile private var mutedPubkeys: Set<String> = emptySet()
+
+    @Volatile private var mutedWords: Set<String> = emptySet()
+
+    // `createdAt` of the last kind-10000 we parsed. Lets the live-event refresh path
+    // (when the aggregator's own kind-10000 arrives via the regular subscription) skip
+    // a redundant decryption round-trip when the event is older than what we already have.
+    @Volatile private var muteListSeenAt: Long = 0L
+
+    // Off-main job running the optional NIP-04/44 decryption of the private mute entries.
+    // Held so stop() / pubkey-change can cancel an in-flight decrypt before the signer
+    // resumes against a stale identity.
+    @Volatile private var muteRefreshJob: Job? = null
+
     @Volatile private var authorCount: Int = 0
 
     @Volatile private var taggedSubId: String? = null
@@ -261,7 +281,17 @@ object RelayAggregator {
         newScope.launch {
             for (ev in newEventChannel) {
                 try {
+                    if (shouldDropForMute(ev)) {
+                        droppedEvents.incrementAndGet()
+                        continue
+                    }
                     CustomWebSocketService.server?.innerProcessEvent(ev, null, fromAggregator = true)
+                    // Owner's mute-list update arriving live (kind 10000) refreshes the in-memory
+                    // sets so subsequent events use the new list without waiting for the next
+                    // periodic refresh tick.
+                    if (ev.kind == 10000 && ev.pubKey == Settings.aggregatorPubkey && ev.createdAt > muteListSeenAt) {
+                        scheduleMuteListRefresh(database)
+                    }
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
@@ -307,6 +337,21 @@ object RelayAggregator {
 
         if (!pausedForMetered) {
             publishStatus(phase = AggregatorPhase.BOOTSTRAPPING)
+        }
+
+        // Warm the mute-list cache from the local DB before the refresh loop kicks off the
+        // network fetch. Ensures the first events admitted after start() respect any mute
+        // entries we already saved on a previous run; no network round-trip on this path.
+        if (Settings.aggregatorPubkey.isNotBlank()) {
+            newScope.launch {
+                try {
+                    loadCachedMuteListFromDb(database.eventDao(), Settings.aggregatorPubkey)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Log.e(TAG, "Warm mute-list load failed", e)
+                }
+            }
         }
 
         newScope.launch {
@@ -368,6 +413,11 @@ object RelayAggregator {
         subscribedRelays.clear()
         connectedRelays.clear()
         lastEventByPubkey.clear()
+        muteRefreshJob?.cancel()
+        muteRefreshJob = null
+        mutedPubkeys = emptySet()
+        mutedWords = emptySet()
+        muteListSeenAt = 0L
         backfilledPubkeys.clear()
         eventsReceived.set(0)
         droppedEvents.set(0)
@@ -697,6 +747,13 @@ object RelayAggregator {
                     relayToAuthors[relay] = mutableSetOf()
                 }
             } else {
+                // Refresh the owner's NIP-51 mute list before opening the main subscriptions.
+                // The public portion is applied synchronously; the (optional) private portion
+                // resolves on its own coroutine via the signer so a slow Amber prompt does not
+                // hold up the rest of the refresh.
+                runCatching { refreshMuteList(dao, aggPubkey) }
+                    .onFailure { Log.e(TAG, "refreshMuteList failed", it) }
+
                 val contactListMs = System.currentTimeMillis()
                 val contactList = loadOrBootstrapContactList(dao, aggPubkey)
                 val follows = contactList?.verifiedFollowKeySet() ?: emptySet()
@@ -1226,6 +1283,196 @@ object RelayAggregator {
             fetchedContactList == null -> cached
             cached == null -> fetchedContactList
             fetchedContactList.createdAt >= cached.createdAt -> fetchedContactList
+            else -> cached
+        }
+    }
+
+    /**
+     * Hot-path mute check used by the consumer coroutine before [innerProcessEvent].
+     * - The aggregator owner's own events are never muted (otherwise refreshing the kind-10000
+     *   itself could be discarded if the owner ever appears in their own list).
+     * - Pubkey check first: O(1) hash lookup, no allocations.
+     * - Word check second: only runs when there are muted words AND the event has content.
+     *   Lower-cases the content once and tests every muted word against the same buffer.
+     */
+    private fun shouldDropForMute(ev: Event): Boolean {
+        if (ev.pubKey == Settings.aggregatorPubkey) return false
+        if (mutedPubkeys.contains(ev.pubKey)) return true
+        val words = mutedWords
+        if (words.isEmpty() || ev.content.isEmpty()) return false
+        val lower = ev.content.lowercase()
+        return words.any { lower.contains(it) }
+    }
+
+    /**
+     * Read whatever kind-10000 the local DB already has for [pubkey] and apply its public
+     * portion to [mutedPubkeys] / [mutedWords]. Called from [start] before the first refresh
+     * so events admitted in the brief window before the network fetch completes still respect
+     * the muted set from a prior session. Does not touch the signer (decryption is reserved
+     * for the network refresh path).
+     */
+    private suspend fun loadCachedMuteListFromDb(dao: EventDao, pubkey: String) {
+        val cached = dao.getMuteList(pubkey)?.toEvent() ?: return
+        if (cached.createdAt <= muteListSeenAt) return
+        val (pubs, words) = extractPublicMuteEntries(cached)
+        mutedPubkeys = pubs
+        mutedWords = words
+        muteListSeenAt = cached.createdAt
+        Log.d(TAG, "Mute list (cache only): ${pubs.size} pubkeys, ${words.size} words (createdAt=${cached.createdAt})")
+    }
+
+    /**
+     * Fetch the freshest kind-10000 for [pubkey] from cache + indexer relays and apply its
+     * public portion synchronously. If a signer is configured and the event has encrypted
+     * content, kick off an off-main job to decrypt the private portion and merge the result.
+     */
+    private suspend fun refreshMuteList(dao: EventDao, pubkey: String) {
+        if (pubkey.isBlank()) return
+        val ev = loadOrBootstrapMuteList(dao, pubkey) ?: run {
+            // Owner has no published mute list yet — clear any stale state from a previous pubkey.
+            mutedPubkeys = emptySet()
+            mutedWords = emptySet()
+            muteListSeenAt = 0L
+            return
+        }
+        if (ev.createdAt <= muteListSeenAt && mutedPubkeys.isNotEmpty()) return
+        val (publicPubs, publicWords) = extractPublicMuteEntries(ev)
+        mutedPubkeys = publicPubs
+        mutedWords = publicWords
+        muteListSeenAt = ev.createdAt
+        Log.d(TAG, "Mute list refreshed (public): ${publicPubs.size} pubkeys, ${publicWords.size} words")
+        scheduleDecryptPrivateMute(ev, publicPubs, publicWords)
+    }
+
+    /**
+     * Trigger an async refresh from the live-event consumer when the owner publishes a new
+     * kind-10000 via their other clients. Re-uses [refreshMuteList] so cache+indexer+decrypt
+     * paths stay identical.
+     */
+    private fun scheduleMuteListRefresh(database: AppDatabase) {
+        val s = scope ?: return
+        muteRefreshJob?.cancel()
+        muteRefreshJob = s.launch {
+            try {
+                refreshMuteList(database.eventDao(), Settings.aggregatorPubkey)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(TAG, "live mute-list refresh failed", e)
+            }
+        }
+    }
+
+    /**
+     * Decrypt the encrypted private mute entries via the configured external signer and merge
+     * them into the in-memory sets. No-op when no signer is configured, the content is empty,
+     * or decryption fails. Logs at debug on failure — never throws.
+     */
+    private fun scheduleDecryptPrivateMute(
+        ev: Event,
+        publicPubs: Set<String>,
+        publicWords: Set<String>,
+    ) {
+        val s = scope ?: return
+        if (ev.content.isEmpty()) return
+        val signer = relayAuthSigner ?: return
+        muteRefreshJob?.cancel()
+        muteRefreshJob = s.launch {
+            try {
+                val plaintext = withTimeoutOrNull(BATCH_FETCH_TIMEOUT_MS) {
+                    // NostrSignerExternal.decrypt routes to NIP-04 or NIP-44 based on the
+                    // ciphertext format, so a single call covers both encoding eras of
+                    // kind-10000 events.
+                    signer.decrypt(ev.content, ev.pubKey)
+                } ?: return@launch
+                val (privPubs, privWords) = parsePrivateMuteTags(plaintext)
+                if (privPubs.isEmpty() && privWords.isEmpty()) return@launch
+                mutedPubkeys = publicPubs + privPubs
+                mutedWords = publicWords + privWords
+                Log.d(
+                    TAG,
+                    "Mute list private merge: +${privPubs.size} pubkeys, +${privWords.size} words " +
+                        "(total ${mutedPubkeys.size} pubkeys, ${mutedWords.size} words)",
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.d(TAG, "Private mute-list decrypt failed: ${e.message}")
+            }
+        }
+    }
+
+    private fun extractPublicMuteEntries(ev: Event): Pair<Set<String>, Set<String>> {
+        val pubs = mutableSetOf<String>()
+        val words = mutableSetOf<String>()
+        for (tag in ev.tags) {
+            if (tag.size < 2) continue
+            when (tag[0]) {
+                "p" -> {
+                    val v = tag[1]
+                    if (v.isNotBlank()) pubs.add(v)
+                }
+                "word" -> {
+                    val v = tag[1].trim().lowercase()
+                    if (v.isNotBlank()) words.add(v)
+                }
+            }
+        }
+        return pubs to words
+    }
+
+    private fun parsePrivateMuteTags(plaintext: String): Pair<Set<String>, Set<String>> {
+        val pubs = mutableSetOf<String>()
+        val words = mutableSetOf<String>()
+        try {
+            val tags: List<List<String>> = JacksonMapper.mapper.readValue(plaintext)
+            for (tag in tags) {
+                if (tag.size < 2) continue
+                when (tag[0]) {
+                    "p" -> {
+                        val v = tag[1]
+                        if (v.isNotBlank()) pubs.add(v)
+                    }
+                    "word" -> {
+                        val v = tag[1].trim().lowercase()
+                        if (v.isNotBlank()) words.add(v)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            Log.d(TAG, "parsePrivateMuteTags failed: ${e.message}")
+        }
+        return pubs to words
+    }
+
+    private suspend fun loadOrBootstrapMuteList(dao: EventDao, pubkey: String): Event? {
+        val cached = dao.getMuteList(pubkey)?.toEvent()
+        val filters = listOf(
+            Filter(
+                kinds = listOf(10000),
+                authors = listOf(pubkey),
+                limit = 1,
+            ),
+        )
+        val subId = newSubId()
+        if (!Citrine.instance.client.isActive()) Citrine.instance.client.connect()
+        val fetched = try {
+            withTimeoutOrNull(BATCH_FETCH_TIMEOUT_MS) {
+                Citrine.instance.client.fetchFirst(subId, INDEXER_RELAYS.associateWith { filters })
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.e(TAG, "bootstrap mute list failed for $pubkey", e)
+            null
+        } finally {
+            runCatching { Citrine.instance.client.unsubscribe(subId) }
+        }
+        fetched?.let { CustomWebSocketService.server?.innerProcessEvent(it, null, fromAggregator = true) }
+        return when {
+            fetched == null -> cached
+            cached == null -> fetched
+            fetched.createdAt >= cached.createdAt -> fetched
             else -> cached
         }
     }


### PR DESCRIPTION
## Summary
Implements NIP-51 (kind 10000) mute list filtering in the relay aggregator, allowing the aggregator owner to mute specific pubkeys and content words. The implementation includes both public and encrypted private mute entries, with efficient hot-path filtering and automatic refresh when the owner publishes a new mute list.

## Key Changes

- **Mute list state management**: Added volatile fields to track muted pubkeys, muted words, and the timestamp of the last parsed mute list. Includes a job reference for managing async decryption tasks.

- **Hot-path filtering**: Implemented `shouldDropForMute()` that performs O(1) pubkey lookups and efficient word matching (single lowercase pass) before event processing. Owner's own events are never muted to prevent self-filtering.

- **Cache warming**: On aggregator start, `loadCachedMuteListFromDb()` loads any previously saved mute list from the local database, ensuring events are filtered immediately without waiting for a network fetch.

- **Network refresh**: `refreshMuteList()` fetches the freshest kind-10000 from indexer relays and applies public mute entries synchronously. Triggers async decryption of private entries via `scheduleDecryptPrivateMute()` if a signer is configured.

- **Live updates**: When the owner publishes a new kind-10000 via other clients, `scheduleMuteListRefresh()` is triggered from the live-event consumer to refresh the in-memory sets without waiting for the periodic refresh tick.

- **Private mute decryption**: `scheduleDecryptPrivateMute()` decrypts encrypted mute entries using the configured external signer (NIP-04 or NIP-44) and merges them with public entries. Runs on a separate coroutine to avoid blocking the main refresh.

- **Mute entry parsing**: `extractPublicMuteEntries()` and `parsePrivateMuteTags()` parse `p` (pubkey) and `word` tags from public and decrypted private content respectively. Words are pre-lowercased for efficient matching.

- **Database query**: Added `getMuteList()` query to `EventDao` to fetch the latest kind-10000 event for a given pubkey.

- **Settings update**: Added kind 10000 to the default `relayAggregatorKinds` set so mute list events are subscribed and cached.

- **Cleanup**: On aggregator stop, mute state is cleared and any in-flight decryption job is cancelled.

## Implementation Details

- Mute pubkeys and words are swapped as a pair to ensure consistent views during partial loads.
- The word matching uses a single lowercase copy of event content to avoid per-word allocations.
- Decryption timeout is set to `BATCH_FETCH_TIMEOUT_MS` to prevent slow signer prompts from blocking the refresh.
- Failures in decryption or parsing are logged at debug level and never throw, allowing the public mute entries to remain active.
- The aggregator owner's pubkey is excluded from muting to prevent the mute list refresh event itself from being filtered.

https://claude.ai/code/session_01Vi7Sd8Amti83xJyo8YfNv4