### PR TITLE
Add kind 10000 to preserved kinds from deletion

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
@@ -13,7 +13,7 @@ object Settings {
     var host: String = "127.0.0.1"
     var port: Int = 4869
     var neverDeleteFrom: Set<String> = emptySet()
-    var preservedKindsFromDeletion: Set<Int> = setOf(0, 3, 10002)
+    var preservedKindsFromDeletion: Set<Int> = setOf(0, 3, 10000, 10002)
     var name: String = "Citrine"
     var ownerPubkey: String = ""
     var contact: String = ""
@@ -64,7 +64,7 @@ object Settings {
         host = "127.0.0.1"
         port = 4869
         neverDeleteFrom = emptySet()
-        preservedKindsFromDeletion = setOf(0, 3, 10002)
+        preservedKindsFromDeletion = setOf(0, 3, 10000, 10002)
         name = "Citrine"
         ownerPubkey = ""
         contact = ""

--- a/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
@@ -125,7 +125,7 @@ object LocalPreferences {
             ?.split(",")
             ?.mapNotNull { it.toIntOrNull() }
             ?.toSet()
-            ?: setOf(0, 3, 10002)
+            ?: setOf(0, 3, 10000, 10002)
         Settings.name = prefs.getString(PrefKeys.RELAY_NAME, "Citrine") ?: "Citrine"
         Settings.ownerPubkey = prefs.getString(PrefKeys.RELAY_OWNER_PUBKEY, "") ?: ""
         Settings.contact = prefs.getString(PrefKeys.RELAY_CONTACT, "") ?: ""


### PR DESCRIPTION
## Summary
Add kind 10000 (Muting list) to the set of event kinds that are preserved from deletion by default in the relay.

## Changes
- Updated `Settings.kt` to include kind 10000 in `preservedKindsFromDeletion` default set (alongside existing kinds 0, 3, and 10002)
- Updated `LocalPreferences.kt` to reflect the same default in the preferences fallback value

## Details
Kind 10000 is a replaceable event kind used for muting lists in the Nostr protocol. By adding it to the preserved kinds, the relay will now protect these events from deletion by default, ensuring users' muting preferences are retained. This aligns with the existing protection of kind 10002 (relay list metadata) and other core event kinds.

https://claude.ai/code/session_01FTjnRhB8cX1z2shKR3HT3G