### PR TITLE
Add multiple connection address options (local, Wi-Fi, Tor)

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/service/WebSocketServerService.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/WebSocketServerService.kt
@@ -27,6 +27,7 @@ import com.greenart7c3.citrine.server.CustomWebSocketServer
 import com.greenart7c3.citrine.server.EventSubscription
 import com.greenart7c3.citrine.server.Settings
 import com.greenart7c3.citrine.utils.ExportDatabaseUtils
+import com.greenart7c3.citrine.utils.NetworkUtils
 import com.vitorpamplona.quartz.utils.TimeUtils
 import java.util.Timer
 import java.util.TimerTask
@@ -233,6 +234,27 @@ class WebSocketServerService : Service() {
                     }
                 }
         }
+
+        scope.launch {
+            // Refresh the notification when Tor finishes bootstrapping so the Copy Tor
+            // action appears with the resolved onion hostname.
+            TorManager.state.collect {
+                try {
+                    val notificationManager = NotificationManagerCompat.from(this@WebSocketServerService)
+                    val status = RelayAggregator.status.value.takeIf { it.enabled }
+                    val notification = createNotification(status)
+                    if (ActivityCompat.checkSelfPermission(
+                            this@WebSocketServerService,
+                            Manifest.permission.POST_NOTIFICATIONS,
+                        ) == PackageManager.PERMISSION_GRANTED
+                    ) {
+                        notificationManager.notify(1, notification)
+                    }
+                } catch (e: Exception) {
+                    Log.e(Citrine.TAG, "Error updating Tor notification", e)
+                }
+            }
+        }
     }
 
     override fun onDestroy() {
@@ -265,16 +287,6 @@ class WebSocketServerService : Service() {
             .build()
         notificationManager.createNotificationChannel(channel)
 
-        val copyIntent = Intent(this, ClipboardReceiver::class.java)
-        copyIntent.putExtra("url", "ws://${Settings.host}:${Settings.port}")
-
-        val copyPendingIntent = PendingIntent.getBroadcast(
-            this,
-            0,
-            copyIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
-        )
-
         val resultIntent = Intent(this, MainActivity::class.java)
 
         val resultPendingIntent = TaskStackBuilder.create(this).run {
@@ -288,9 +300,41 @@ class WebSocketServerService : Service() {
             .setContentTitle(getString(R.string.relay_running_at_ws, Settings.host, Settings.port.toString()))
             .setSmallIcon(R.drawable.ic_notification)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .addAction(R.drawable.ic_launcher_background, getString(R.string.copy_address), copyPendingIntent)
             .setContentIntent(resultPendingIntent)
             .setGroup(groupId)
+
+        // requestCode is used to disambiguate each PendingIntent's extras, otherwise
+        // FLAG_UPDATE_CURRENT would have them all share the most recently set URL.
+        val localUrl = "ws://127.0.0.1:${Settings.port}"
+        notificationBuilder.addAction(
+            R.drawable.ic_launcher_background,
+            getString(R.string.copy_local),
+            copyPendingIntent(localUrl, requestCode = 1),
+        )
+
+        val wifiIp = NetworkUtils.getLocalIpAddress()
+        if (!wifiIp.isNullOrBlank()) {
+            val wifiUrl = "ws://$wifiIp:${Settings.port}"
+            notificationBuilder.addAction(
+                R.drawable.ic_launcher_background,
+                getString(R.string.copy_wifi),
+                copyPendingIntent(wifiUrl, requestCode = 2),
+            )
+        }
+
+        val torState = TorManager.state.value
+        val onionHost = when (torState) {
+            is TorManager.State.Running -> torState.hostname.takeIf { it.isNotBlank() }
+            else -> Settings.onionHostname.takeIf { it.isNotBlank() && Settings.useTor }
+        }
+        if (!onionHost.isNullOrBlank()) {
+            val torUrl = "ws://$onionHost"
+            notificationBuilder.addAction(
+                R.drawable.ic_launcher_background,
+                getString(R.string.copy_tor),
+                copyPendingIntent(torUrl, requestCode = 3),
+            )
+        }
 
         if (status != null && status.enabled) {
             val summary = buildAggregatorSummary(status)
@@ -304,6 +348,17 @@ class WebSocketServerService : Service() {
     }
 
     fun isStarted(): Boolean = CustomWebSocketService.server != null
+
+    private fun copyPendingIntent(url: String, requestCode: Int): PendingIntent {
+        val intent = Intent(this, ClipboardReceiver::class.java)
+        intent.putExtra("url", url)
+        return PendingIntent.getBroadcast(
+            this,
+            requestCode,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
+        )
+    }
 
     private fun buildAggregatorSummary(status: AggregatorStatus): String {
         val phase = when (status.phase) {

--- a/app/src/main/java/com/greenart7c3/citrine/ui/HomeScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/HomeScreen.kt
@@ -1,7 +1,6 @@
 package com.greenart7c3.citrine.ui
 
 import android.app.Activity.RESULT_OK
-import android.content.ClipData
 import android.content.Intent
 import android.util.Log
 import android.widget.Toast
@@ -36,8 +35,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.ClipEntry
-import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -58,11 +55,13 @@ import com.greenart7c3.citrine.server.Settings
 import com.greenart7c3.citrine.service.CustomWebSocketService
 import com.greenart7c3.citrine.service.LocalPreferences
 import com.greenart7c3.citrine.service.RelayAggregator
+import com.greenart7c3.citrine.ui.components.AddressRow
 import com.greenart7c3.citrine.ui.components.AggregatorStatusCard
 import com.greenart7c3.citrine.ui.components.RelayInfo
 import com.greenart7c3.citrine.ui.dialogs.DeleteAllDialog
 import com.greenart7c3.citrine.ui.dialogs.ImportEventsDialog
 import com.greenart7c3.citrine.ui.navigation.Route
+import com.greenart7c3.citrine.utils.NetworkUtils
 import com.vitorpamplona.quartz.nip19Bech32.Nip19Parser
 import com.vitorpamplona.quartz.nip19Bech32.entities.NPub
 import com.vitorpamplona.quartz.nip55AndroidSigner.client.NostrSignerExternal
@@ -315,37 +314,28 @@ fun HomeScreen(
                 CircularProgressIndicator()
             } else {
                 val isStarted = homeViewModel.state.value.service?.isStarted() ?: false
-                val clipboardManager = LocalClipboard.current
                 if (isStarted) {
                     Text(stringResource(R.string.relay_started_at))
-                    Text(
-                        "ws://${Settings.host}:${Settings.port}",
-                        modifier = Modifier.clickable {
-                            coroutineScope.launch {
-                                clipboardManager.setClipEntry(
-                                    ClipEntry(
-                                        ClipData.newPlainText("", "ws://${Settings.host}:${Settings.port}"),
-                                    ),
-                                )
-                            }
-                        },
+                    AddressRow(
+                        label = stringResource(R.string.address_local),
+                        address = "ws://127.0.0.1:${Settings.port}",
                     )
+                    val wifiIp = remember(state.value) { NetworkUtils.getLocalIpAddress() }
+                    if (!wifiIp.isNullOrBlank()) {
+                        AddressRow(
+                            label = stringResource(R.string.address_wifi),
+                            address = "ws://$wifiIp:${Settings.port}",
+                        )
+                    }
                     if (Settings.useTor) {
                         val torState by com.greenart7c3.citrine.service.TorManager.state.collectAsStateWithLifecycle()
                         when (val s = torState) {
                             com.greenart7c3.citrine.service.TorManager.State.Off -> {
                                 if (Settings.onionHostname.isNotBlank()) {
-                                    val onionUrl = "ws://${Settings.onionHostname}"
-                                    Text(
-                                        onionUrl,
+                                    AddressRow(
+                                        label = stringResource(R.string.address_tor),
+                                        address = "ws://${Settings.onionHostname}",
                                         color = Color.Gray,
-                                        modifier = Modifier.clickable {
-                                            coroutineScope.launch {
-                                                clipboardManager.setClipEntry(
-                                                    ClipEntry(ClipData.newPlainText("", onionUrl)),
-                                                )
-                                            }
-                                        },
                                     )
                                 }
                             }
@@ -354,16 +344,9 @@ fun HomeScreen(
                             }
                             is com.greenart7c3.citrine.service.TorManager.State.Running -> {
                                 if (s.hostname.isNotBlank()) {
-                                    val onionUrl = "ws://${s.hostname}"
-                                    Text(
-                                        onionUrl,
-                                        modifier = Modifier.clickable {
-                                            coroutineScope.launch {
-                                                clipboardManager.setClipEntry(
-                                                    ClipEntry(ClipData.newPlainText("", onionUrl)),
-                                                )
-                                            }
-                                        },
+                                    AddressRow(
+                                        label = stringResource(R.string.address_tor),
+                                        address = "ws://${s.hostname}",
                                     )
                                 }
                             }

--- a/app/src/main/java/com/greenart7c3/citrine/ui/components/AddressRow.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/components/AddressRow.kt
@@ -1,0 +1,65 @@
+package com.greenart7c3.citrine.ui.components
+
+import android.content.ClipData
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.greenart7c3.citrine.R
+import kotlinx.coroutines.launch
+
+@Composable
+fun AddressRow(
+    label: String,
+    address: String,
+    color: Color = Color.Unspecified,
+) {
+    val clipboardManager = LocalClipboard.current
+    val coroutineScope = rememberCoroutineScope()
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            modifier = Modifier.weight(1f),
+            text = "$label: $address",
+            color = color,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        IconButton(
+            onClick = {
+                coroutineScope.launch {
+                    clipboardManager.setClipEntry(
+                        ClipEntry(ClipData.newPlainText("", address)),
+                    )
+                }
+            },
+        ) {
+            Icon(
+                modifier = Modifier.size(20.dp),
+                imageVector = Icons.Default.ContentCopy,
+                contentDescription = stringResource(R.string.copy_address),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/greenart7c3/citrine/utils/NetworkUtils.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/utils/NetworkUtils.kt
@@ -1,0 +1,26 @@
+package com.greenart7c3.citrine.utils
+
+import android.util.Log
+import com.greenart7c3.citrine.Citrine
+import java.net.Inet4Address
+import java.net.NetworkInterface
+
+object NetworkUtils {
+    fun getLocalIpAddress(): String? = try {
+        NetworkInterface.getNetworkInterfaces()
+            .toList()
+            .asSequence()
+            .filter { it.isUp && !it.isLoopback && !it.isVirtual }
+            .flatMap { it.inetAddresses.toList().asSequence() }
+            .firstOrNull { addr ->
+                !addr.isLoopbackAddress &&
+                    !addr.isLinkLocalAddress &&
+                    addr is Inet4Address &&
+                    addr.isSiteLocalAddress
+            }
+            ?.hostAddress
+    } catch (e: Exception) {
+        Log.w(Citrine.TAG, "Failed to determine local IP address", e)
+        null
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,12 @@
     <string name="show_events">Show events</string>
     <string name="copy_address">Copy Address</string>
     <string name="relay_running_at_ws">Relay running at ws://%1$s:%2$s</string>
+    <string name="address_local">Local</string>
+    <string name="address_wifi">Wi-Fi</string>
+    <string name="address_tor">Tor</string>
+    <string name="copy_local">Copy Local</string>
+    <string name="copy_wifi">Copy Wi-Fi</string>
+    <string name="copy_tor">Copy Tor</string>
     <string name="go_back">Go back</string>
     <string name="total">Total: %1$s</string>
     <string name="kind">Kind</string>


### PR DESCRIPTION
## Summary
Enhance the relay connection experience by displaying and providing copy actions for multiple connection addresses: localhost, local Wi-Fi IP, and Tor onion address. This allows users to easily connect from different network contexts.

## Key Changes

- **New `NetworkUtils` utility** — Added `getLocalIpAddress()` to detect the device's local Wi-Fi IPv4 address by filtering network interfaces for non-loopback, non-virtual, site-local addresses.

- **New `AddressRow` Compose component** — Reusable UI component that displays a labeled address with an inline copy-to-clipboard button, reducing duplication across screens.

- **Enhanced notification actions** — Updated `WebSocketServerService.createNotification()` to provide three separate copy actions in the foreground service notification:
  - Copy Local (127.0.0.1)
  - Copy Wi-Fi (detected local IP)
  - Copy Tor (onion hostname when available)
  - Each action uses a unique `requestCode` to disambiguate `PendingIntent` extras

- **Notification refresh on Tor bootstrap** — Added a new coroutine scope in `WebSocketServerService.onCreate()` that listens to `TorManager.state` changes and refreshes the notification when Tor finishes bootstrapping, ensuring the onion hostname appears in the copy action once available.

- **Refactored `HomeScreen` address display** — Replaced inline clickable text elements with the new `AddressRow` component for all three address types (local, Wi-Fi, Tor), improving consistency and maintainability.

- **String resources** — Added new localized strings for address labels and copy action descriptions (`address_local`, `address_wifi`, `address_tor`, `copy_local`, `copy_wifi`, `copy_tor`).

## Implementation Details

- The `copyPendingIntent()` helper method was extracted to reduce code duplication when creating multiple copy actions with different URLs and request codes.
- Wi-Fi address detection gracefully handles cases where no local IP is available (e.g., on cellular-only devices).
- Tor address logic checks both the current `TorManager.State.Running` hostname and the persisted `Settings.onionHostname` for offline scenarios.
- The notification refresh mechanism ensures users see the Tor address as soon as it becomes available, improving the UX for Tor-enabled relays.

https://claude.ai/code/session_017LEfx9vKWwRHrqRZEX1jSX