### PR TITLE
Implement NIP-70: Block reposts that embed protected events

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/provider/CitrineContentProvider.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/provider/CitrineContentProvider.kt
@@ -597,6 +597,9 @@ class CitrineContentProvider : ContentProvider() {
                         CustomWebSocketServer.VerificationResult.AuthRequiredForProtectedEvent -> {
                             QueryResult.error<Uri>("Authentication required for protected event")
                         }
+                        CustomWebSocketServer.VerificationResult.ProtectedEventEmbeddedInRepost -> {
+                            QueryResult.error<Uri>("Reposts of protected events must not embed the reposted event")
+                        }
                     }
                 } else {
                     // Server not available, do basic validation and insert

--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -40,6 +40,8 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
 import com.vitorpamplona.quartz.nip01Core.tags.aTag.taggedAddresses
 import com.vitorpamplona.quartz.nip01Core.tags.events.taggedEvents
 import com.vitorpamplona.quartz.nip01Core.tags.people.taggedUsers
+import com.vitorpamplona.quartz.nip18Reposts.GenericRepostEvent
+import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
 import com.vitorpamplona.quartz.nip40Expiration.expiration
 import com.vitorpamplona.quartz.nip40Expiration.isExpired
 import com.vitorpamplona.quartz.nip42RelayAuth.RelayAuthEvent
@@ -349,6 +351,7 @@ class CustomWebSocketServer(
         TaggedPubKeyMismatch,
         NewestEventAlreadyInDatabase,
         AuthRequiredForProtectedEvent,
+        ProtectedEventEmbeddedInRepost,
     }
 
     suspend fun verifyEvent(event: Event, connection: Connection?, shouldVerify: Boolean, fromAggregator: Boolean = false): VerificationResult {
@@ -392,6 +395,19 @@ class CustomWebSocketServer(
             if (!isLocalHost && !connection.users.contains(event.pubKey)) {
                 Log.d(Citrine.TAG, "auth required for protected event ${event.id}")
                 return VerificationResult.AuthRequiredForProtectedEvent
+            }
+        }
+
+        // NIP-70: reposts of protected events MUST NOT embed the reposted event.
+        if (event.kind == RepostEvent.KIND || event.kind == GenericRepostEvent.KIND) {
+            val embedded = try {
+                Event.fromJson(event.content)
+            } catch (_: Exception) {
+                null
+            }
+            if (embedded != null && embedded.isProtected()) {
+                Log.d(Citrine.TAG, "rejecting repost ${event.id} that embeds protected event ${embedded.id}")
+                return VerificationResult.ProtectedEventEmbeddedInRepost
             }
         }
 
@@ -481,6 +497,9 @@ class CustomWebSocketServer(
             VerificationResult.AuthRequiredForProtectedEvent -> {
                 connection?.trySend(AuthResult.challenge(connection.authChallenge).toJson())
                 connection?.trySend(CommandResult.required(event, "this event may only be published by its author").toJson())
+            }
+            VerificationResult.ProtectedEventEmbeddedInRepost -> {
+                connection?.trySend(CommandResult.invalid(event, "blocked: reposts of protected events must not embed the reposted event").toJson())
             }
             VerificationResult.InvalidId -> {
                 connection?.trySend(


### PR DESCRIPTION
## Summary
Adds validation to prevent reposts of protected events from embedding the reposted event content, as required by NIP-70. This ensures that protected events cannot be exposed through repost mechanisms.

## Changes
- **Import NIP-18 repost types**: Added imports for `RepostEvent` and `GenericRepostEvent` from quartz library to identify repost events
- **Add validation result type**: Introduced `ProtectedEventEmbeddedInRepost` to the `VerificationResult` enum to represent this specific validation failure
- **Implement NIP-70 check in `verifyEvent()`**: Added logic to detect when a repost (kind 6 or 16) embeds a protected event by:
  - Attempting to parse the repost's content as a JSON event
  - Checking if the embedded event is protected via `isProtected()`
  - Rejecting the repost with appropriate logging if a protected event is found
- **Handle rejection in event processing**: Updated `innerProcessEvent()` to send an "invalid" command result when a repost embeds a protected event
- **Update content provider error handling**: Added corresponding error case in `CitrineContentProvider` to surface the validation error to other Android apps querying via ContentResolver

## Implementation Details
The validation occurs early in the `verifyEvent()` pipeline (before signature verification) to efficiently reject invalid reposts. The check safely handles malformed content by catching exceptions during JSON parsing, treating unparseable content as non-embedded events.

https://claude.ai/code/session_01U3s7BSJzohBuTrgd8Z9jLU