### PR TITLE
Make relay aggregator indexer and source relays user-configurable

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
@@ -5,6 +5,17 @@ import com.greenart7c3.citrine.R
 import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
 
 object Settings {
+    val DEFAULT_AGGREGATOR_SOURCE_RELAYS = setOf(
+        "wss://aggr.nostr.land/",
+    )
+
+    val DEFAULT_NIP65_INDEXER_RELAYS = setOf(
+        "wss://purplepag.es/",
+        "wss://user.kindpag.es/",
+        "wss://profiles.nostr1.com/",
+        "wss://directory.yabu.me/",
+    )
+
     var allowedKinds: Set<Int> = emptySet()
     var allowedPubKeys: Set<String> = emptySet()
     var allowedTaggedPubKeys: Set<String> = emptySet()
@@ -41,6 +52,17 @@ object Settings {
     // Relays the aggregator listens to when no pubkey is configured — plain kinds+since
     // subscription, no author filter. Also usable as an explicit extra relay set.
     var relayAggregatorExtraRelays: Set<String> = emptySet()
+
+    // External aggregator-style relays (e.g. wss://aggr.nostr.land) that mirror events
+    // from many upstreams. Subscribed for the full author set on every refresh, in
+    // addition to each author's per-relay NIP-65 routing.
+    var relayAggregatorSourceRelays: Set<String> = DEFAULT_AGGREGATOR_SOURCE_RELAYS
+
+    // Relays consulted only to look up NIP-65 (kind 10002), contact-list (kind 3), and
+    // mute-list (kind 10000) records when not already cached locally. An empty user
+    // value falls back to DEFAULT_NIP65_INDEXER_RELAYS at read time so NIP-65 lookups
+    // never silently break.
+    var relayAggregatorIndexerRelays: Set<String> = DEFAULT_NIP65_INDEXER_RELAYS
 
     // When true, the aggregator suspends subscriptions whenever the active network is
     // metered (mobile data or metered Wi-Fi) and resumes once an unmetered network is
@@ -88,6 +110,8 @@ object Settings {
         relayAggregatorIncludeTagged = true
         relayAggregatorLastSync = 0L
         relayAggregatorExtraRelays = emptySet()
+        relayAggregatorSourceRelays = DEFAULT_AGGREGATOR_SOURCE_RELAYS
+        relayAggregatorIndexerRelays = DEFAULT_NIP65_INDEXER_RELAYS
         relayAggregatorWifiOnly = true
         aggregatorSignerPubkey = ""
         aggregatorSignerPackageName = ""

--- a/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
@@ -41,6 +41,8 @@ object PrefKeys {
     const val RELAY_AGGREGATOR_INCLUDE_TAGGED = "relay_aggregator_include_tagged"
     const val RELAY_AGGREGATOR_LAST_SYNC = "relay_aggregator_last_sync"
     const val RELAY_AGGREGATOR_EXTRA_RELAYS = "relay_aggregator_extra_relays"
+    const val RELAY_AGGREGATOR_SOURCE_RELAYS = "relay_aggregator_source_relays"
+    const val RELAY_AGGREGATOR_INDEXER_RELAYS = "relay_aggregator_indexer_relays"
     const val RELAY_AGGREGATOR_WIFI_ONLY = "relay_aggregator_wifi_only"
     const val AGGREGATOR_SIGNER_PUBKEY = "aggregator_signer_pubkey"
     const val AGGREGATOR_SIGNER_PACKAGE_NAME = "aggregator_signer_package_name"
@@ -104,6 +106,8 @@ object LocalPreferences {
                 putBoolean(PrefKeys.RELAY_AGGREGATOR_INCLUDE_TAGGED, settings.relayAggregatorIncludeTagged)
                 putLong(PrefKeys.RELAY_AGGREGATOR_LAST_SYNC, settings.relayAggregatorLastSync)
                 putStringSet(PrefKeys.RELAY_AGGREGATOR_EXTRA_RELAYS, settings.relayAggregatorExtraRelays)
+                putStringSet(PrefKeys.RELAY_AGGREGATOR_SOURCE_RELAYS, settings.relayAggregatorSourceRelays)
+                putStringSet(PrefKeys.RELAY_AGGREGATOR_INDEXER_RELAYS, settings.relayAggregatorIndexerRelays)
                 putBoolean(PrefKeys.RELAY_AGGREGATOR_WIFI_ONLY, settings.relayAggregatorWifiOnly)
                 putString(PrefKeys.AGGREGATOR_SIGNER_PUBKEY, settings.aggregatorSignerPubkey)
                 putString(PrefKeys.AGGREGATOR_SIGNER_PACKAGE_NAME, settings.aggregatorSignerPackageName)
@@ -158,6 +162,10 @@ object LocalPreferences {
         Settings.relayAggregatorIncludeTagged = prefs.getBoolean(PrefKeys.RELAY_AGGREGATOR_INCLUDE_TAGGED, true)
         Settings.relayAggregatorLastSync = prefs.getLong(PrefKeys.RELAY_AGGREGATOR_LAST_SYNC, 0L)
         Settings.relayAggregatorExtraRelays = prefs.getStringSet(PrefKeys.RELAY_AGGREGATOR_EXTRA_RELAYS, emptySet()) ?: emptySet()
+        Settings.relayAggregatorSourceRelays = prefs.getStringSet(PrefKeys.RELAY_AGGREGATOR_SOURCE_RELAYS, null)
+            ?: Settings.DEFAULT_AGGREGATOR_SOURCE_RELAYS
+        Settings.relayAggregatorIndexerRelays = prefs.getStringSet(PrefKeys.RELAY_AGGREGATOR_INDEXER_RELAYS, null)
+            ?: Settings.DEFAULT_NIP65_INDEXER_RELAYS
         Settings.relayAggregatorWifiOnly = prefs.getBoolean(PrefKeys.RELAY_AGGREGATOR_WIFI_ONLY, true)
         Settings.aggregatorSignerPubkey = prefs.getString(PrefKeys.AGGREGATOR_SIGNER_PUBKEY, "") ?: ""
         Settings.aggregatorSignerPackageName = prefs.getString(PrefKeys.AGGREGATOR_SIGNER_PACKAGE_NAME, "") ?: ""

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -79,13 +79,6 @@ private data class ChunkSubscription(
 object RelayAggregator {
     private const val TAG = "RelayAggregator"
 
-    private val INDEXER_RELAYS = listOf(
-        RelayUrlNormalizer.normalize("wss://purplepag.es/"),
-        RelayUrlNormalizer.normalize("wss://user.kindpag.es/"),
-        RelayUrlNormalizer.normalize("wss://profiles.nostr1.com/"),
-        RelayUrlNormalizer.normalize("wss://directory.yabu.me/"),
-    )
-
     private val FALLBACK_OUTBOX_RELAYS = listOf(
         RelayUrlNormalizer.normalize("wss://relay.damus.io/"),
         RelayUrlNormalizer.normalize("wss://nos.lol/"),
@@ -94,6 +87,13 @@ object RelayAggregator {
 
     // Keep well under the per-filter author cap that stricter relays enforce (often 100–200).
     private const val MAX_AUTHORS_PER_SUB = 100
+
+    // Per-author cap on how many of the author's NIP-65 write relays we'll actually
+    // subscribe to. Lower = fewer concurrent WebSockets and less battery drain; higher
+    // = better redundancy if any one relay drops events. The greedy picker (capRelaysPerAuthor)
+    // prefers relays that already cover other authors so the chosen set converges to a
+    // small number of well-shared relays even with a large follow list.
+    private const val MAX_RELAYS_PER_AUTHOR = 3
     private const val DEFAULT_COLD_START_WINDOW_SEC = 24L * 60L * 60L
     private const val OVERLAP_SEC = 5L * 60L
     private const val BATCH_FETCH_TIMEOUT_MS = 15_000L
@@ -765,6 +765,9 @@ object RelayAggregator {
                         "${follows.size} follows (+ self) for $aggPubkey (createdAt=${contactList?.createdAt ?: "none"})",
                 )
 
+                val indexers = indexerRelays()
+                val sources = aggregatorSourceRelays()
+
                 // Resolve NIP-65 for all authors in one batch instead of N sequential fetches.
                 val uncached = mutableSetOf<String>()
                 for (pk in authors) {
@@ -775,8 +778,8 @@ object RelayAggregator {
 
                 val fetchMs = System.currentTimeMillis()
                 fetched = if (uncached.isNotEmpty()) {
-                    Log.d(TAG, "Fetching ${uncached.size} NIP-65 records from ${INDEXER_RELAYS.size} indexers")
-                    batchFetchRelayLists(uncached, INDEXER_RELAYS, BATCH_FETCH_TIMEOUT_MS)
+                    Log.d(TAG, "Fetching ${uncached.size} NIP-65 records from ${indexers.size} indexers")
+                    batchFetchRelayLists(uncached, indexers, BATCH_FETCH_TIMEOUT_MS)
                 } else {
                     emptyMap()
                 }
@@ -788,10 +791,16 @@ object RelayAggregator {
                     )
                 }
 
+                // Build each author's candidate write-relay list (with the per-author
+                // fallback for missing NIP-65), then cap each author at MAX_RELAYS_PER_AUTHOR
+                // using a greedy popularity-based picker to converge on a small shared set
+                // of relays. Aggregator-source relays are then layered on top with the full
+                // author set, so they act as a backstop mirror for every followed pubkey.
+                val authorWriteRelays = mutableMapOf<String, List<NormalizedRelayUrl>>()
                 var fellBackCount = 0
                 for (pk in authors) {
                     val relayListEvent = cachedRelayLists[pk] ?: fetched[pk]
-                    val writeRelays = relayListEvent
+                    authorWriteRelays[pk] = relayListEvent
                         ?.writeRelays()
                         ?.mapNotNull { raw -> normalizeRemote(raw) }
                         ?.takeIf { it.isNotEmpty() }
@@ -799,34 +808,38 @@ object RelayAggregator {
                             fellBackCount++
                             FALLBACK_OUTBOX_RELAYS
                         }
-                    writeRelays.forEach { relay ->
-                        relayToAuthors.getOrPut(relay) { mutableSetOf() }.add(pk)
-                    }
+                }
+                val capped = capRelaysPerAuthor(authorWriteRelays, MAX_RELAYS_PER_AUTHOR)
+                relayToAuthors.putAll(capped)
+                sources.forEach { relay ->
+                    relayToAuthors.getOrPut(relay) { mutableSetOf() }.addAll(authors)
                 }
                 Log.d(
                     TAG,
                     "Outbox map built: ${relayToAuthors.size} relays for ${authors.size} authors " +
-                        "($fellBackCount author(s) had no NIP-65, fell back to ${FALLBACK_OUTBOX_RELAYS.size} relays)",
+                        "(cap=$MAX_RELAYS_PER_AUTHOR/author, ${sources.size} aggregator source(s), " +
+                        "$fellBackCount author(s) had no NIP-65, fell back to ${FALLBACK_OUTBOX_RELAYS.size} relays)",
                 )
 
-                // Route each author's kind-0 fetch to their NIP-65 write relays when known,
-                // falling back to the indexer relays for authors without a relay list. Reuses
-                // the cached + freshly fetched NIP-65 maps resolved above.
-                val metadataRelayToAuthors = mutableMapOf<NormalizedRelayUrl, MutableSet<String>>()
+                // Same cap-then-overlay-sources strategy for kind-0 metadata fetches: take
+                // each author's NIP-65 write relays (indexers as the fallback for unknown
+                // authors), cap per-author, then add the aggregator-source relays.
+                val authorMetadataRelays = mutableMapOf<String, List<NormalizedRelayUrl>>()
                 var metadataIndexerFallback = 0
                 for (pk in authors) {
                     val relayListEvent = cachedRelayLists[pk] ?: fetched[pk]
-                    val targetRelays = relayListEvent
+                    authorMetadataRelays[pk] = relayListEvent
                         ?.writeRelays()
                         ?.mapNotNull { raw -> normalizeRemote(raw) }
                         ?.takeIf { it.isNotEmpty() }
                         ?: run {
                             metadataIndexerFallback++
-                            INDEXER_RELAYS
+                            indexers
                         }
-                    targetRelays.forEach { relay ->
-                        metadataRelayToAuthors.getOrPut(relay) { mutableSetOf() }.add(pk)
-                    }
+                }
+                val metadataRelayToAuthors = capRelaysPerAuthor(authorMetadataRelays, MAX_RELAYS_PER_AUTHOR)
+                sources.forEach { relay ->
+                    metadataRelayToAuthors.getOrPut(relay) { mutableSetOf() }.addAll(authors)
                 }
                 val metadataMs = System.currentTimeMillis()
                 val metadataFetched = batchFetchMetadata(metadataRelayToAuthors, BATCH_FETCH_TIMEOUT_MS)
@@ -834,7 +847,8 @@ object RelayAggregator {
                     TAG,
                     "Metadata batch fetch returned ${metadataFetched.size}/${authors.size} " +
                         "from ${metadataRelayToAuthors.size} relays " +
-                        "($metadataIndexerFallback author(s) had no NIP-65, fell back to indexers) " +
+                        "(cap=$MAX_RELAYS_PER_AUTHOR/author, ${sources.size} aggregator source(s), " +
+                        "$metadataIndexerFallback author(s) had no NIP-65, fell back to indexers) " +
                         "in ${System.currentTimeMillis() - metadataMs}ms",
                 )
             }
@@ -1166,6 +1180,46 @@ object RelayAggregator {
         return NormalizedRelayUrl(url = n.url)
     }
 
+    // Resolves the user-configured NIP-65 indexer relays. An empty user set falls back to
+    // the built-in defaults so NIP-65 / contact-list / mute-list bootstrap lookups never
+    // silently break when the user clears the list.
+    private fun indexerRelays(): List<NormalizedRelayUrl> {
+        val raw = Settings.relayAggregatorIndexerRelays
+            .takeIf { it.isNotEmpty() }
+            ?: Settings.DEFAULT_NIP65_INDEXER_RELAYS
+        return raw.mapNotNull { normalizeRemote(it) }
+    }
+
+    // Resolves the user-configured aggregator-source relays (e.g. wss://aggr.nostr.land).
+    // No default fallback: an empty user list means "no aggregator overlay", which is a
+    // legitimate configuration (rely entirely on per-author NIP-65 routing).
+    private fun aggregatorSourceRelays(): List<NormalizedRelayUrl> = Settings.relayAggregatorSourceRelays.mapNotNull { normalizeRemote(it) }
+
+    // Picks at most [cap] relays per author from each author's candidate write-relay list,
+    // greedily preferring relays that already cover many other authors. The popularity
+    // score is computed across all authors once, then each author independently picks its
+    // top-[cap] relays by that score with ties broken by candidate-list order. This keeps
+    // total open WebSocket count low while still spreading coverage across multiple relays
+    // per author.
+    private fun capRelaysPerAuthor(
+        authorWriteRelays: Map<String, List<NormalizedRelayUrl>>,
+        cap: Int,
+    ): MutableMap<NormalizedRelayUrl, MutableSet<String>> {
+        val relayPopularity = mutableMapOf<NormalizedRelayUrl, Int>()
+        for ((_, relays) in authorWriteRelays) {
+            for (r in relays.distinct()) relayPopularity.merge(r, 1) { a, b -> a + b }
+        }
+        val result = mutableMapOf<NormalizedRelayUrl, MutableSet<String>>()
+        for ((pk, relays) in authorWriteRelays) {
+            val chosen = relays
+                .distinct()
+                .sortedByDescending { relayPopularity[it] ?: 0 }
+                .take(cap)
+            chosen.forEach { r -> result.getOrPut(r) { mutableSetOf() }.add(pk) }
+        }
+        return result
+    }
+
     /**
      * Fetches a single replaceable event of [kind] for [pubkey] from [relays] with no `since`
      * filter. Used both for the user's own kind 3 / kind 0 and for opportunistic backfill of
@@ -1219,19 +1273,20 @@ object RelayAggregator {
             "Backfilling unknown user $pubkey " +
                 "(metadata=$needsMetadata, contacts=$needsContactList, relayList=$needsRelayList)",
         )
+        val indexers = indexerRelays()
         if (needsRelayList) {
-            fetchSingleReplaceable(AdvertisedRelayListEvent.KIND, pubkey, INDEXER_RELAYS)?.let {
+            fetchSingleReplaceable(AdvertisedRelayListEvent.KIND, pubkey, indexers)?.let {
                 CustomWebSocketService.server?.innerProcessEvent(it, null, fromAggregator = true)
             }
         }
         if (needsMetadata) {
-            val metadataRelays = userWriteRelays(dao, pubkey) ?: INDEXER_RELAYS
+            val metadataRelays = userWriteRelays(dao, pubkey) ?: indexers
             fetchSingleReplaceable(MetadataEvent.KIND, pubkey, metadataRelays)?.let {
                 CustomWebSocketService.server?.innerProcessEvent(it, null, fromAggregator = true)
             }
         }
         if (needsContactList) {
-            fetchSingleReplaceable(ContactListEvent.KIND, pubkey, INDEXER_RELAYS)?.let {
+            fetchSingleReplaceable(ContactListEvent.KIND, pubkey, indexers)?.let {
                 CustomWebSocketService.server?.innerProcessEvent(it, null, fromAggregator = true)
             }
         }
@@ -1266,7 +1321,7 @@ object RelayAggregator {
         if (!Citrine.instance.client.isActive()) Citrine.instance.client.connect()
         val fetched = try {
             withTimeoutOrNull(BATCH_FETCH_TIMEOUT_MS) {
-                Citrine.instance.client.fetchFirst(subId, INDEXER_RELAYS.associateWith { filters })
+                Citrine.instance.client.fetchFirst(subId, indexerRelays().associateWith { filters })
             }
         } catch (e: CancellationException) {
             throw e
@@ -1458,7 +1513,7 @@ object RelayAggregator {
         if (!Citrine.instance.client.isActive()) Citrine.instance.client.connect()
         val fetched = try {
             withTimeoutOrNull(BATCH_FETCH_TIMEOUT_MS) {
-                Citrine.instance.client.fetchFirst(subId, INDEXER_RELAYS.associateWith { filters })
+                Citrine.instance.client.fetchFirst(subId, indexerRelays().associateWith { filters })
             }
         } catch (e: CancellationException) {
             throw e

--- a/app/src/main/java/com/greenart7c3/citrine/ui/settings/AggregatorSettingsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/settings/AggregatorSettingsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -73,6 +74,10 @@ fun AggregatorSettingsScreen(
         var aggregatorWifiOnly by remember { mutableStateOf(Settings.relayAggregatorWifiOnly) }
         var aggregatorExtraRelays by remember { mutableStateOf(Settings.relayAggregatorExtraRelays) }
         var aggregatorExtraRelayInput by remember { mutableStateOf(TextFieldValue("")) }
+        var aggregatorSourceRelays by remember { mutableStateOf(Settings.relayAggregatorSourceRelays) }
+        var aggregatorSourceRelayInput by remember { mutableStateOf(TextFieldValue("")) }
+        var aggregatorIndexerRelays by remember { mutableStateOf(Settings.relayAggregatorIndexerRelays) }
+        var aggregatorIndexerRelayInput by remember { mutableStateOf(TextFieldValue("")) }
         var aggregatorSignerPubkey by remember { mutableStateOf(Settings.aggregatorSignerPubkey) }
         var aggregatorSignerPackageName by remember { mutableStateOf(Settings.aggregatorSignerPackageName) }
 
@@ -142,6 +147,8 @@ fun AggregatorSettingsScreen(
                 Settings.relayAggregatorIncludeTagged = aggregatorIncludeTagged
                 Settings.relayAggregatorWifiOnly = aggregatorWifiOnly
                 Settings.relayAggregatorExtraRelays = aggregatorExtraRelays
+                Settings.relayAggregatorSourceRelays = aggregatorSourceRelays
+                Settings.relayAggregatorIndexerRelays = aggregatorIndexerRelays
                 LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
 
                 aggregatorPubkey = TextFieldValue(resolvedAggregatorKey)
@@ -320,6 +327,104 @@ fun AggregatorSettingsScreen(
                     PubkeyListItem(
                         text = relay,
                         onDelete = { aggregatorExtraRelays = aggregatorExtraRelays - relay },
+                    )
+                }
+                item {
+                    Text(
+                        text = stringResource(R.string.relay_aggregator_source_relays),
+                        style = MaterialTheme.typography.titleSmall,
+                        modifier = Modifier.padding(top = 12.dp),
+                    )
+                }
+                item {
+                    Text(
+                        text = stringResource(R.string.relay_aggregator_source_relays_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(bottom = 4.dp),
+                    )
+                }
+                item {
+                    PubkeyInputRow(
+                        value = aggregatorSourceRelayInput,
+                        onValueChange = { aggregatorSourceRelayInput = it },
+                        onPaste = {
+                            scope.launch {
+                                val text = clipboardManager.getClipEntry()?.clipData?.getItemAt(0)?.text?.toString() ?: return@launch
+                                aggregatorSourceRelayInput = TextFieldValue(text)
+                            }
+                        },
+                        onAdd = {
+                            val normalized = normalizeRelayInput(aggregatorSourceRelayInput.text)
+                            if (normalized == null) {
+                                Toast.makeText(context, context.getString(R.string.relay_aggregator_invalid_relay), Toast.LENGTH_SHORT).show()
+                                return@PubkeyInputRow
+                            }
+                            aggregatorSourceRelays = aggregatorSourceRelays + normalized
+                            aggregatorSourceRelayInput = TextFieldValue("")
+                        },
+                    )
+                }
+                item {
+                    TextButton(
+                        onClick = { aggregatorSourceRelays = Settings.DEFAULT_AGGREGATOR_SOURCE_RELAYS },
+                    ) {
+                        Text(stringResource(R.string.relay_aggregator_reset_defaults))
+                    }
+                }
+                items(aggregatorSourceRelays.toList()) { relay ->
+                    PubkeyListItem(
+                        text = relay,
+                        onDelete = { aggregatorSourceRelays = aggregatorSourceRelays - relay },
+                    )
+                }
+                item {
+                    Text(
+                        text = stringResource(R.string.relay_aggregator_indexer_relays),
+                        style = MaterialTheme.typography.titleSmall,
+                        modifier = Modifier.padding(top = 12.dp),
+                    )
+                }
+                item {
+                    Text(
+                        text = stringResource(R.string.relay_aggregator_indexer_relays_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(bottom = 4.dp),
+                    )
+                }
+                item {
+                    PubkeyInputRow(
+                        value = aggregatorIndexerRelayInput,
+                        onValueChange = { aggregatorIndexerRelayInput = it },
+                        onPaste = {
+                            scope.launch {
+                                val text = clipboardManager.getClipEntry()?.clipData?.getItemAt(0)?.text?.toString() ?: return@launch
+                                aggregatorIndexerRelayInput = TextFieldValue(text)
+                            }
+                        },
+                        onAdd = {
+                            val normalized = normalizeRelayInput(aggregatorIndexerRelayInput.text)
+                            if (normalized == null) {
+                                Toast.makeText(context, context.getString(R.string.relay_aggregator_invalid_relay), Toast.LENGTH_SHORT).show()
+                                return@PubkeyInputRow
+                            }
+                            aggregatorIndexerRelays = aggregatorIndexerRelays + normalized
+                            aggregatorIndexerRelayInput = TextFieldValue("")
+                        },
+                    )
+                }
+                item {
+                    TextButton(
+                        onClick = { aggregatorIndexerRelays = Settings.DEFAULT_NIP65_INDEXER_RELAYS },
+                    ) {
+                        Text(stringResource(R.string.relay_aggregator_reset_defaults))
+                    }
+                }
+                items(aggregatorIndexerRelays.toList()) { relay ->
+                    PubkeyListItem(
+                        text = relay,
+                        onDelete = { aggregatorIndexerRelays = aggregatorIndexerRelays - relay },
                     )
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,6 +136,11 @@
     <string name="relay_aggregator_extra_relays">Extra relays</string>
     <string name="relay_aggregator_extra_relays_description">Relays subscribed with a plain kinds/since filter (no author filter). Used as the full relay set when no pubkey is configured.</string>
     <string name="relay_aggregator_extra_relays_hint">Add at least one relay to run without a pubkey</string>
+    <string name="relay_aggregator_source_relays">Aggregator relays</string>
+    <string name="relay_aggregator_source_relays_description">External aggregator-style relays (for example aggr.nostr.land) that mirror events from many upstreams. Subscribed for every configured kind with your full follow set.</string>
+    <string name="relay_aggregator_indexer_relays">NIP-65 indexer relays</string>
+    <string name="relay_aggregator_indexer_relays_description">Used only to look up authors\' NIP-65 relay lists, contact lists, and mute lists when not already cached. Leave empty to use the built-in defaults.</string>
+    <string name="relay_aggregator_reset_defaults">Reset to defaults</string>
     <string name="relay_aggregator_invalid_relay">Invalid relay URL (expected wss:// or ws://)</string>
     <string name="relay_aggregator_pubkey_or_relays_required">Set an aggregator pubkey or at least one relay first</string>
     <string name="relay_aggregator_phase_idle">Idle</string>


### PR DESCRIPTION
## Summary

Refactors the relay aggregator to make NIP-65 indexer relays and aggregator-source relays user-configurable via settings, while introducing a greedy per-author relay capping strategy to reduce WebSocket overhead and battery drain.

## Key Changes

- **Configurable indexer relays**: Moved hardcoded `INDEXER_RELAYS` constant into `Settings.relayAggregatorIndexerRelays` with a fallback to `DEFAULT_NIP65_INDEXER_RELAYS` when empty, ensuring NIP-65 lookups never silently break
- **Configurable aggregator-source relays**: Added new `Settings.relayAggregatorSourceRelays` (defaults to `wss://aggr.nostr.land/`) for external aggregator mirrors that are subscribed with the full author set
- **Per-author relay capping**: Introduced `MAX_RELAYS_PER_AUTHOR = 3` constant and new `capRelaysPerAuthor()` function that greedily picks the most popular relays across all authors, reducing concurrent WebSocket connections while maintaining redundancy
- **Unified relay routing strategy**: Both outbox (kind 0 metadata) and event subscriptions now use the same cap-then-overlay pattern: cap each author's NIP-65 write relays, then layer aggregator-source relays on top with the full author set
- **Settings UI**: Added two new sections in `AggregatorSettingsScreen` for managing indexer and source relays with add/remove/reset-to-defaults functionality
- **Persistence**: Extended `LocalPreferences` and `Settings` to serialize/deserialize the new relay configuration sets

## Implementation Details

- The `indexerRelays()` and `aggregatorSourceRelays()` helper functions resolve user settings at runtime, allowing dynamic reconfiguration without restart
- The greedy popularity-based picker in `capRelaysPerAuthor()` computes relay scores once across all authors, then each author independently selects its top-N relays by that score, converging the relay set toward a small number of well-shared relays
- Aggregator-source relays are always subscribed for the full author set (no per-author cap), acting as a backstop mirror
- Logging updated to show the capping strategy and source relay count in batch fetch operations
- All existing backfill and single-event fetch paths updated to use `indexerRelays()` instead of the hardcoded constant

https://claude.ai/code/session_013a7oKLMvVdTAwyA1mrhuuK