### PR TITLE
Optimize notification updates with signature-based deduplication

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/service/WebSocketServerService.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/WebSocketServerService.kt
@@ -45,6 +45,14 @@ class WebSocketServerService : Service() {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val binder = LocalBinder()
     private var timer: Timer? = null
+
+    // Signature of the last notification we posted to id 1, used to skip re-posting
+    // identical content. Re-posting an unchanged notification can still wake the
+    // device and refresh the system UI, even with setOnlyAlertOnce.
+    @Volatile private var lastForegroundSignature: String? = null
+
+    // Signature of the last backup-progress notification we posted to id 2.
+    @Volatile private var lastBackupProgressText: String? = null
     inner class LocalBinder : Binder() {
         fun getService(): WebSocketServerService = this@WebSocketServerService
     }
@@ -69,6 +77,7 @@ class WebSocketServerService : Service() {
                 override fun run() {
                     if ((Citrine.job == null || Citrine.job?.isCompleted == true) && !Citrine.isImportingEvents) {
                         NotificationManagerCompat.from(Citrine.instance).cancel(2)
+                        lastBackupProgressText = null
                     }
 
                     if (!Citrine.isImportingEvents) {
@@ -100,7 +109,8 @@ class WebSocketServerService : Service() {
                                                 val notificationManager = NotificationManagerCompat.from(Citrine.instance)
                                                 if (it.isBlank()) {
                                                     notificationManager.cancel(2)
-                                                } else {
+                                                    lastBackupProgressText = null
+                                                } else if (it != lastBackupProgressText) {
                                                     val channel = NotificationChannelCompat.Builder(
                                                         "citrine",
                                                         NotificationManagerCompat.IMPORTANCE_DEFAULT,
@@ -130,6 +140,7 @@ class WebSocketServerService : Service() {
 
                                                     if (ActivityCompat.checkSelfPermission(Citrine.instance, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
                                                         notificationManager.notify(2, notification)
+                                                        lastBackupProgressText = it
                                                     }
                                                 }
                                             },
@@ -201,7 +212,9 @@ class WebSocketServerService : Service() {
         var attempts = 0
         while (error && attempts < 5) {
             try {
-                startForeground(1, createNotification(RelayAggregator.status.value.takeIf { it.enabled }))
+                val initial = buildForegroundNotification(RelayAggregator.status.value.takeIf { it.enabled })
+                startForeground(1, initial.notification)
+                lastForegroundSignature = initial.signature
                 error = false
             } catch (e: Exception) {
                 Log.e(Citrine.TAG, "Error starting foreground service attempt $attempts", e)
@@ -220,15 +233,7 @@ class WebSocketServerService : Service() {
                 .sample(NOTIFICATION_THROTTLE_MS)
                 .collect { status ->
                     try {
-                        val notificationManager = NotificationManagerCompat.from(this@WebSocketServerService)
-                        val notification = createNotification(status.takeIf { it.enabled })
-                        if (ActivityCompat.checkSelfPermission(
-                                this@WebSocketServerService,
-                                Manifest.permission.POST_NOTIFICATIONS,
-                            ) == PackageManager.PERMISSION_GRANTED
-                        ) {
-                            notificationManager.notify(1, notification)
-                        }
+                        postForegroundNotificationIfChanged(status.takeIf { it.enabled })
                     } catch (e: Exception) {
                         Log.e(Citrine.TAG, "Error updating aggregator notification", e)
                     }
@@ -240,16 +245,7 @@ class WebSocketServerService : Service() {
             // action appears with the resolved onion hostname.
             TorManager.state.collect {
                 try {
-                    val notificationManager = NotificationManagerCompat.from(this@WebSocketServerService)
-                    val status = RelayAggregator.status.value.takeIf { it.enabled }
-                    val notification = createNotification(status)
-                    if (ActivityCompat.checkSelfPermission(
-                            this@WebSocketServerService,
-                            Manifest.permission.POST_NOTIFICATIONS,
-                        ) == PackageManager.PERMISSION_GRANTED
-                    ) {
-                        notificationManager.notify(1, notification)
-                    }
+                    postForegroundNotificationIfChanged(RelayAggregator.status.value.takeIf { it.enabled })
                 } catch (e: Exception) {
                     Log.e(Citrine.TAG, "Error updating Tor notification", e)
                 }
@@ -271,7 +267,11 @@ class WebSocketServerService : Service() {
 
     override fun onBind(intent: Intent?): IBinder = binder
 
-    private fun createNotification(status: AggregatorStatus? = null): Notification {
+    private data class ForegroundNotification(val notification: Notification, val signature: String)
+
+    private fun createNotification(status: AggregatorStatus? = null): Notification = buildForegroundNotification(status).notification
+
+    private fun buildForegroundNotification(status: AggregatorStatus? = null): ForegroundNotification {
         val notificationManager = NotificationManagerCompat.from(this)
         val channelId = "WebSocketServerServiceChannel"
         val groupId = "WebSocketServerServiceGroup"
@@ -296,10 +296,12 @@ class WebSocketServerService : Service() {
             getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
         }
 
+        val title = getString(R.string.relay_running_at_ws, Settings.host, Settings.port.toString())
         val notificationBuilder = NotificationCompat.Builder(this, "WebSocketServerServiceChannel")
-            .setContentTitle(getString(R.string.relay_running_at_ws, Settings.host, Settings.port.toString()))
+            .setContentTitle(title)
             .setSmallIcon(R.drawable.ic_notification)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setOnlyAlertOnce(true)
             .setContentIntent(resultPendingIntent)
             .setGroup(groupId)
 
@@ -313,8 +315,8 @@ class WebSocketServerService : Service() {
         )
 
         val wifiIp = NetworkUtils.getLocalIpAddress()
-        if (!wifiIp.isNullOrBlank()) {
-            val wifiUrl = "ws://$wifiIp:${Settings.port}"
+        val wifiUrl = if (!wifiIp.isNullOrBlank()) "ws://$wifiIp:${Settings.port}" else null
+        if (wifiUrl != null) {
             notificationBuilder.addAction(
                 R.drawable.ic_launcher_background,
                 getString(R.string.copy_wifi),
@@ -327,8 +329,8 @@ class WebSocketServerService : Service() {
             is TorManager.State.Running -> torState.hostname.takeIf { it.isNotBlank() }
             else -> Settings.onionHostname.takeIf { it.isNotBlank() && Settings.useTor }
         }
-        if (!onionHost.isNullOrBlank()) {
-            val torUrl = "ws://$onionHost"
+        val torUrl = if (!onionHost.isNullOrBlank()) "ws://$onionHost" else null
+        if (torUrl != null) {
             notificationBuilder.addAction(
                 R.drawable.ic_launcher_background,
                 getString(R.string.copy_tor),
@@ -336,15 +338,36 @@ class WebSocketServerService : Service() {
             )
         }
 
+        val summary: String
+        val details: String
         if (status != null && status.enabled) {
-            val summary = buildAggregatorSummary(status)
-            val details = buildAggregatorDetails(status)
+            summary = buildAggregatorSummary(status)
+            details = buildAggregatorDetails(status)
             notificationBuilder
                 .setContentText(summary)
                 .setStyle(NotificationCompat.BigTextStyle().bigText(details))
+        } else {
+            summary = ""
+            details = ""
         }
 
-        return notificationBuilder.build()
+        val signature = listOf(title, summary, details, localUrl, wifiUrl.orEmpty(), torUrl.orEmpty())
+            .joinToString("")
+        return ForegroundNotification(notificationBuilder.build(), signature)
+    }
+
+    private fun postForegroundNotificationIfChanged(status: AggregatorStatus?) {
+        val built = buildForegroundNotification(status)
+        if (built.signature == lastForegroundSignature) return
+        if (ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            return
+        }
+        NotificationManagerCompat.from(this).notify(1, built.notification)
+        lastForegroundSignature = built.signature
     }
 
     fun isStarted(): Boolean = CustomWebSocketService.server != null


### PR DESCRIPTION
## Summary
Optimize foreground and backup-progress notifications by tracking content signatures and only posting when the notification content actually changes. This prevents unnecessary device wake-ups and system UI refreshes that can occur even with `setOnlyAlertOnce(true)`.

## Key Changes
- **Foreground notification deduplication**: Added `lastForegroundSignature` volatile field to track the last posted foreground notification (ID 1). Extract notification building logic into `buildForegroundNotification()` that returns both the notification and a content signature. Only post if the signature differs from the last one.
- **Backup-progress notification deduplication**: Added `lastBackupProgressText` volatile field to track the last posted backup-progress notification (ID 2). Only post when the progress text changes, and clear the field when the notification is cancelled.
- **Refactored notification posting**: Created `postForegroundNotificationIfChanged()` helper method to centralize the deduplication logic and permission checks. Updated both the relay aggregator status and Tor state collectors to use this new method.
- **Improved notification building**: Extracted notification title and URL building into local variables for cleaner signature generation. Added `setOnlyAlertOnce(true)` to the foreground notification builder for additional protection against unwanted alerts.
- **Signature generation**: Foreground notification signature is computed from title, aggregator summary, aggregator details, and all available URLs (local, WiFi, Tor) concatenated together.

## Implementation Details
- Signatures are computed deterministically from the notification content, ensuring identical notifications produce identical signatures
- The `ForegroundNotification` data class encapsulates both the built notification and its signature for type safety
- Volatile fields ensure thread-safe visibility across coroutine contexts
- Null checks are preserved for all optional content (WiFi IP, Tor hostname, aggregator status)

https://claude.ai/code/session_011RXaRWmrEG7XmQkQ6HVwjN