### PR TITLE
Refactor connection lifecycle and improve graceful shutdown

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/server/Connection.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Connection.kt
@@ -2,16 +2,17 @@ package com.greenart7c3.citrine.server
 
 import android.util.Log
 import com.greenart7c3.citrine.Citrine
-import com.greenart7c3.citrine.service.CustomWebSocketService
 import com.vitorpamplona.negentropy.Negentropy
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import io.ktor.server.websocket.DefaultWebSocketServerSession
 import io.ktor.websocket.Frame
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.onClosed
 import kotlinx.coroutines.delay
@@ -30,17 +31,27 @@ class Connection(
 
     val negentropySessions: MutableMap<String, Negentropy> = ConcurrentHashMap()
 
+    val closed = AtomicBoolean(false)
+
     val since = System.currentTimeMillis()
-    private val inactivityJob: Job = Citrine.instance.applicationScope.launch {
-        while (isActive) {
-            delay(60_000)
-            val hasTenMinutesPassed = System.currentTimeMillis() - since > 10 * 60 * 1000
-            if (hasTenMinutesPassed && !EventSubscription.containsConnection(this@Connection)) {
-                Log.d(Citrine.TAG, "Closing session due to inactivity")
-                finalize()
-                session.cancel()
-                CustomWebSocketService.server?.removeConnection(this@Connection)
-                break
+
+    private val connectionScope = CoroutineScope(
+        Citrine.instance.applicationScope.coroutineContext + SupervisorJob(),
+    )
+
+    init {
+        connectionScope.launch {
+            while (isActive) {
+                delay(60_000)
+                val hasTenMinutesPassed = System.currentTimeMillis() - since > 10 * 60 * 1000
+                if (hasTenMinutesPassed && !EventSubscription.containsConnection(this@Connection)) {
+                    Log.d(Citrine.TAG, "Closing session due to inactivity for $name")
+                    try {
+                        session.cancel()
+                    } catch (_: Throwable) {
+                    }
+                    break
+                }
             }
         }
     }
@@ -58,7 +69,7 @@ class Connection(
     }
 
     fun finalize() {
-        inactivityJob.cancel()
+        connectionScope.cancel()
         EventSubscription.closeAll(name)
         negentropySessions.clear()
     }
@@ -66,13 +77,8 @@ class Connection(
     fun trySend(data: String) {
         try {
             session.outgoing.trySend(Frame.Text(data)).onClosed {
-                val connection = EventSubscription.getConnection(session)
-                connection?.let {
-                    Log.d(Citrine.TAG, "Session is closed for connection ${connection.name} ${connection.remoteAddress}")
-                    Citrine.instance.applicationScope.launch {
-                        CustomWebSocketService.server?.removeConnection(connection)
-                    }
-                }
+                Log.d(Citrine.TAG, "Session is closed for connection $name $remoteAddress")
+                // Do not call removeConnection here — the webSocket finally block owns removal.
             }
         } catch (e: Exception) {
             if (e is CancellationException) throw e

--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -83,7 +83,6 @@ import io.ktor.websocket.Frame
 import io.ktor.websocket.WebSocketDeflateExtension
 import io.ktor.websocket.readText
 import java.net.ServerSocket
-import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.zip.Deflater
 import kotlinx.coroutines.CancellationException
@@ -94,16 +93,19 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 
 class CustomWebSocketServer(
     private val host: String,
     private val port: Int,
     private val appDatabase: AppDatabase,
 ) {
-    val connections = MutableStateFlow(Collections.synchronizedList<Connection>(mutableListOf()))
+    val connections = MutableStateFlow<List<Connection>>(emptyList())
     lateinit var server: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>
     private val webClientServers = ConcurrentHashMap<String, WebClientServer>()
     private val objectMapper = jacksonObjectMapper()
@@ -142,6 +144,19 @@ class CustomWebSocketServer(
     fun stop() {
         Log.d(Citrine.TAG, "Stopping server")
         if (::server.isInitialized) {
+            val snapshot = connections.value.toList()
+            runBlocking {
+                withTimeoutOrNull(5_000) {
+                    snapshot.forEach { conn ->
+                        try {
+                            removeConnection(conn)
+                        } catch (e: Throwable) {
+                            Log.w(Citrine.TAG, "Error removing ${conn.name} during stop", e)
+                        }
+                    }
+                }
+            }
+            EventSubscription.closeAll()
             server.stop()
             webClientServers.forEach {
                 it.value.server.stop()
@@ -1225,7 +1240,7 @@ class CustomWebSocketServer(
                 // WebSocket endpoint
                 webSocket("/") {
                     val thisConnection = Connection(this)
-                    connections.emit(connections.value + thisConnection)
+                    connections.update { it + thisConnection }
 
                     Log.d(Citrine.TAG, "New connection from ${this.call.request.local.remoteHost} ${thisConnection.name}")
 
@@ -1262,10 +1277,14 @@ class CustomWebSocketServer(
     }
 
     suspend fun removeConnection(connection: Connection) {
+        if (!connection.closed.compareAndSet(false, true)) return
         Log.d(Citrine.TAG, "Removing ${connection.name}!")
-        connection.session.cancel()
         connection.finalize()
-        connections.emit(connections.value.filterNot { it === connection })
+        try {
+            connection.session.cancel()
+        } catch (_: Throwable) {
+        }
+        connections.update { list -> list.filterNot { it === connection } }
     }
 }
 

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventSubscription.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventSubscription.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 private val ENVELOPE_MAPPER = JacksonMapper.mapper
@@ -74,7 +74,7 @@ object EventSubscription {
         subscriptions.snapshot().entries.forEach { (key, manager) ->
             if (manager.subscription.connection.name == connectionName) {
                 Log.d(Citrine.TAG, "closing subscription $key")
-                manager.subscription.scope.coroutineContext.cancelChildren()
+                manager.subscription.scope.cancel()
                 subscriptions.remove(key)
             }
         }
@@ -87,7 +87,7 @@ object EventSubscription {
     }
 
     fun close(subscriptionId: String) {
-        subscriptions.get(subscriptionId)?.subscription?.scope?.coroutineContext?.cancelChildren()
+        subscriptions.get(subscriptionId)?.subscription?.scope?.cancel()
         subscriptions.remove(subscriptionId)
     }
 

--- a/app/src/main/java/com/greenart7c3/citrine/service/WebSocketServerService.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/WebSocketServerService.kt
@@ -36,8 +36,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 
 private const val NOTIFICATION_THROTTLE_MS = 5_000L
 
@@ -254,14 +257,21 @@ class WebSocketServerService : Service() {
     }
 
     override fun onDestroy() {
-        scope.launch(Dispatchers.IO) {
-            timer?.cancel()
-            timer = null
-            RelayAggregator.stop()
-            EventSubscription.closeAll()
-            CustomWebSocketService.server?.stop()
-            TorManager.stop()
+        runBlocking {
+            withTimeoutOrNull(5_000) {
+                try {
+                    timer?.cancel()
+                    timer = null
+                    RelayAggregator.stop()
+                    EventSubscription.closeAll()
+                    CustomWebSocketService.server?.stop()
+                    TorManager.stop()
+                } catch (e: Throwable) {
+                    Log.e(Citrine.TAG, "Error during service onDestroy cleanup", e)
+                }
+            }
         }
+        scope.cancel()
         super.onDestroy()
     }
 


### PR DESCRIPTION
## Summary
This PR refactors WebSocket connection lifecycle management to improve reliability and enable graceful shutdown. The changes address race conditions in connection removal, simplify inactivity timeout handling, and ensure proper cleanup during service destruction.

## Key Changes

- **Connection lifecycle improvements:**
  - Introduced `AtomicBoolean closed` flag to prevent duplicate removal attempts via `compareAndSet()`
  - Moved inactivity timeout logic from a shared job into a connection-scoped `CoroutineScope` with `SupervisorJob()`
  - Removed dependency on `CustomWebSocketService.server` reference from `Connection` class
  - Simplified `trySend()` to log closure without triggering removal (ownership moved to WebSocket finally block)

- **Server shutdown handling:**
  - Added explicit connection cleanup in `CustomWebSocketServer.stop()` with 5-second timeout
  - Changed `connections` from `Collections.synchronizedList()` to immutable `MutableStateFlow<List<Connection>>`
  - Updated connection list mutations to use `flow.update()` instead of `emit()`
  - Reordered `removeConnection()` to finalize before canceling session, with exception handling

- **Service cleanup:**
  - Wrapped `WebSocketServerService.onDestroy()` in `runBlocking` with 5-second timeout to ensure synchronous cleanup
  - Added explicit `scope.cancel()` after cleanup operations
  - Improved error logging during shutdown

- **EventSubscription cleanup:**
  - Changed `cancelChildren()` to `scope.cancel()` for complete scope cancellation in `closeAll()` and `close()`

## Implementation Details

The refactoring eliminates a circular dependency where `Connection` held a reference to `CustomWebSocketService.server` for removal. Now removal is coordinated through `CustomWebSocketServer.removeConnection()` with atomic guards to prevent concurrent removal attempts. The inactivity timeout is now scoped to each connection rather than shared, improving isolation and testability.

Graceful shutdown is now explicit: the server collects a snapshot of connections and removes each with error handling, ensuring no connections are orphaned during service destruction.

https://claude.ai/code/session_01Jsax8rFpphbxPbRYosv5qF