### PR TITLE
Pause aggregator on limited/restricted networks

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
@@ -70,6 +70,12 @@ object Settings {
     // is the dominant battery cost on cellular.
     var relayAggregatorWifiOnly: Boolean = true
 
+    // When true, the aggregator suspends subscriptions whenever the active network lacks
+    // NET_CAPABILITY_NOT_RESTRICTED — i.e., a "limited"/restricted network such as a
+    // captive-portal hotspot or an enterprise network that blocks general internet
+    // traffic. Resumes automatically once an unrestricted network is available.
+    var relayAggregatorPauseOnLimitedNetwork: Boolean = true
+
     // External signer used by the aggregator to answer NIP-42 AUTH challenges from upstream
     // relays. Populated by the "Log in with external signer" flow in settings. When both
     // fields are set, the aggregator installs a RelayAuthenticator and signs kind-22242
@@ -113,6 +119,7 @@ object Settings {
         relayAggregatorSourceRelays = DEFAULT_AGGREGATOR_SOURCE_RELAYS
         relayAggregatorIndexerRelays = DEFAULT_NIP65_INDEXER_RELAYS
         relayAggregatorWifiOnly = true
+        relayAggregatorPauseOnLimitedNetwork = true
         aggregatorSignerPubkey = ""
         aggregatorSignerPackageName = ""
     }

--- a/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
@@ -44,6 +44,7 @@ object PrefKeys {
     const val RELAY_AGGREGATOR_SOURCE_RELAYS = "relay_aggregator_source_relays"
     const val RELAY_AGGREGATOR_INDEXER_RELAYS = "relay_aggregator_indexer_relays"
     const val RELAY_AGGREGATOR_WIFI_ONLY = "relay_aggregator_wifi_only"
+    const val RELAY_AGGREGATOR_PAUSE_ON_LIMITED_NETWORK = "relay_aggregator_pause_on_limited_network"
     const val AGGREGATOR_SIGNER_PUBKEY = "aggregator_signer_pubkey"
     const val AGGREGATOR_SIGNER_PACKAGE_NAME = "aggregator_signer_package_name"
 }
@@ -109,6 +110,7 @@ object LocalPreferences {
                 putStringSet(PrefKeys.RELAY_AGGREGATOR_SOURCE_RELAYS, settings.relayAggregatorSourceRelays)
                 putStringSet(PrefKeys.RELAY_AGGREGATOR_INDEXER_RELAYS, settings.relayAggregatorIndexerRelays)
                 putBoolean(PrefKeys.RELAY_AGGREGATOR_WIFI_ONLY, settings.relayAggregatorWifiOnly)
+                putBoolean(PrefKeys.RELAY_AGGREGATOR_PAUSE_ON_LIMITED_NETWORK, settings.relayAggregatorPauseOnLimitedNetwork)
                 putString(PrefKeys.AGGREGATOR_SIGNER_PUBKEY, settings.aggregatorSignerPubkey)
                 putString(PrefKeys.AGGREGATOR_SIGNER_PACKAGE_NAME, settings.aggregatorSignerPackageName)
             }
@@ -167,6 +169,7 @@ object LocalPreferences {
         Settings.relayAggregatorIndexerRelays = prefs.getStringSet(PrefKeys.RELAY_AGGREGATOR_INDEXER_RELAYS, null)
             ?: Settings.DEFAULT_NIP65_INDEXER_RELAYS
         Settings.relayAggregatorWifiOnly = prefs.getBoolean(PrefKeys.RELAY_AGGREGATOR_WIFI_ONLY, true)
+        Settings.relayAggregatorPauseOnLimitedNetwork = prefs.getBoolean(PrefKeys.RELAY_AGGREGATOR_PAUSE_ON_LIMITED_NETWORK, true)
         Settings.aggregatorSignerPubkey = prefs.getString(PrefKeys.AGGREGATOR_SIGNER_PUBKEY, "") ?: ""
         Settings.aggregatorSignerPackageName = prefs.getString(PrefKeys.AGGREGATOR_SIGNER_PACKAGE_NAME, "") ?: ""
     }

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -177,10 +177,12 @@ object RelayAggregator {
     // to detect identity changes and trigger a full restart.
     @Volatile private var currentPubkey: String? = null
 
-    // True while subscriptions are torn down because the active network is metered and
-    // [Settings.relayAggregatorWifiOnly] is enabled. The refresh loop checks this flag and
-    // skips its body until [resumeFromMetered] resets it.
-    @Volatile private var pausedForMetered: Boolean = false
+    // True while subscriptions are torn down because the active network triggered a pause
+    // condition — either it is metered with [Settings.relayAggregatorWifiOnly] enabled, or
+    // it is restricted/limited with [Settings.relayAggregatorPauseOnLimitedNetwork] enabled.
+    // The refresh loop checks this flag and skips its body until [resumeFromNetwork] resets
+    // it.
+    @Volatile private var pausedForNetwork: Boolean = false
 
     // The database the aggregator was started with — saved so the network callback can
     // trigger a refresh on resume without the caller threading it through.
@@ -338,7 +340,7 @@ object RelayAggregator {
         // wifi-only, start in the paused state instead of opening subs.
         evaluateNetworkState()
 
-        if (!pausedForMetered) {
+        if (!pausedForNetwork) {
             publishStatus(phase = AggregatorPhase.BOOTSTRAPPING)
         }
 
@@ -359,7 +361,7 @@ object RelayAggregator {
 
         newScope.launch {
             while (isActive) {
-                if (!pausedForMetered) {
+                if (!pausedForNetwork) {
                     try {
                         refreshAndSubscribe(database)
                         consecutiveFailures = 0
@@ -429,7 +431,7 @@ object RelayAggregator {
         authorCount = 0
         taggedSubIds.clear()
         currentPubkey = null
-        pausedForMetered = false
+        pausedForNetwork = false
         database = null
         lastRefreshFinishedAt = 0L
         consecutiveFailures = 0
@@ -556,6 +558,16 @@ object RelayAggregator {
         return !caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
     }
 
+    private fun isOnLimitedNetwork(): Boolean {
+        val cm = connectivityManager() ?: return false
+        val net = cm.activeNetwork ?: return false
+        val caps = cm.getNetworkCapabilities(net) ?: return false
+        // Same rationale as above: when there's no internet capability at all, don't claim
+        // the network is "limited" — let other failure paths handle it.
+        if (!caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) return false
+        return !caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_RESTRICTED)
+    }
+
     private fun registerNetworkCallback() {
         if (networkCallback != null) return
         val cm = connectivityManager() ?: return
@@ -589,24 +601,25 @@ object RelayAggregator {
     }
 
     /**
-     * Reconciles the current network state against the wifi-only setting and pauses or
-     * resumes the aggregator accordingly. Cheap to call repeatedly; only acts when the
-     * desired state diverges from the actual one.
+     * Reconciles the current network state against the wifi-only and pause-on-limited
+     * settings, pausing or resuming the aggregator accordingly. Cheap to call repeatedly;
+     * only acts when the desired state diverges from the actual one.
      */
     @Synchronized
     private fun evaluateNetworkState() {
         if (scope == null) return
-        val shouldPause = Settings.relayAggregatorWifiOnly && isOnMeteredNetwork()
-        if (shouldPause && !pausedForMetered) {
-            pauseForMetered()
-        } else if (!shouldPause && pausedForMetered) {
-            resumeFromMetered()
+        val shouldPause = (Settings.relayAggregatorWifiOnly && isOnMeteredNetwork()) ||
+            (Settings.relayAggregatorPauseOnLimitedNetwork && isOnLimitedNetwork())
+        if (shouldPause && !pausedForNetwork) {
+            pauseForNetwork()
+        } else if (!shouldPause && pausedForNetwork) {
+            resumeFromNetwork()
         }
     }
 
-    private fun pauseForMetered() {
-        Log.d(TAG, "Pausing aggregator: metered network detected and wifi-only enabled")
-        pausedForMetered = true
+    private fun pauseForNetwork() {
+        Log.d(TAG, "Pausing aggregator: network pause condition triggered")
+        pausedForNetwork = true
         // Tear down active subscriptions so we stop receiving events. Keep
         // [lastEventByPubkey] and [currentPubkey] in place — when we resume, the next
         // refresh uses them to compute tight per-chunk `since` values.
@@ -619,9 +632,9 @@ object RelayAggregator {
         publishStatus(phase = AggregatorPhase.PAUSED)
     }
 
-    private fun resumeFromMetered() {
-        Log.d(TAG, "Resuming aggregator: unmetered network available")
-        pausedForMetered = false
+    private fun resumeFromNetwork() {
+        Log.d(TAG, "Resuming aggregator: network pause condition cleared")
+        pausedForNetwork = false
         publishStatus(phase = AggregatorPhase.BOOTSTRAPPING)
         val db = database ?: return
         scope?.launch {
@@ -667,10 +680,10 @@ object RelayAggregator {
                 // without a full restart.
                 scope?.let { installAuthenticatorIfNeeded(it) }
                 // The wifi-only toggle may have just changed; re-evaluate before
-                // dispatching a refresh so a flip to "pause on metered" doesn't kick
-                // off a doomed refresh that we'd immediately tear down.
+                // dispatching a refresh so a flip to any network-based pause condition
+                // doesn't kick off a doomed refresh that we'd immediately tear down.
                 evaluateNetworkState()
-                if (!pausedForMetered) {
+                if (!pausedForNetwork) {
                     scope?.launch {
                         Log.d(TAG, "Config change: triggering refresh for running aggregator")
                         try {
@@ -691,8 +704,8 @@ object RelayAggregator {
             Log.d(TAG, "Import in progress; skipping refresh")
             return
         }
-        if (pausedForMetered) {
-            Log.d(TAG, "Paused for metered network; skipping refresh")
+        if (pausedForNetwork) {
+            Log.d(TAG, "Paused for network condition; skipping refresh")
             return
         }
         if (!refreshing.compareAndSet(false, true)) {

--- a/app/src/main/java/com/greenart7c3/citrine/ui/settings/AggregatorSettingsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/settings/AggregatorSettingsScreen.kt
@@ -72,6 +72,7 @@ fun AggregatorSettingsScreen(
         }
         var aggregatorIncludeTagged by remember { mutableStateOf(Settings.relayAggregatorIncludeTagged) }
         var aggregatorWifiOnly by remember { mutableStateOf(Settings.relayAggregatorWifiOnly) }
+        var aggregatorPauseOnLimitedNetwork by remember { mutableStateOf(Settings.relayAggregatorPauseOnLimitedNetwork) }
         var aggregatorExtraRelays by remember { mutableStateOf(Settings.relayAggregatorExtraRelays) }
         var aggregatorExtraRelayInput by remember { mutableStateOf(TextFieldValue("")) }
         var aggregatorSourceRelays by remember { mutableStateOf(Settings.relayAggregatorSourceRelays) }
@@ -146,6 +147,7 @@ fun AggregatorSettingsScreen(
                 Settings.relayAggregatorRefreshMinutes = refreshMinutes
                 Settings.relayAggregatorIncludeTagged = aggregatorIncludeTagged
                 Settings.relayAggregatorWifiOnly = aggregatorWifiOnly
+                Settings.relayAggregatorPauseOnLimitedNetwork = aggregatorPauseOnLimitedNetwork
                 Settings.relayAggregatorExtraRelays = aggregatorExtraRelays
                 Settings.relayAggregatorSourceRelays = aggregatorSourceRelays
                 Settings.relayAggregatorIndexerRelays = aggregatorIndexerRelays
@@ -241,6 +243,14 @@ fun AggregatorSettingsScreen(
                         description = stringResource(R.string.relay_aggregator_wifi_only_description),
                         checked = aggregatorWifiOnly,
                         onCheckedChange = { aggregatorWifiOnly = it },
+                    )
+                }
+                item {
+                    SwitchSettingRow(
+                        title = stringResource(R.string.relay_aggregator_pause_on_limited_network),
+                        description = stringResource(R.string.relay_aggregator_pause_on_limited_network_description),
+                        checked = aggregatorPauseOnLimitedNetwork,
+                        onCheckedChange = { aggregatorPauseOnLimitedNetwork = it },
                     )
                 }
                 item {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,8 @@
     <string name="relay_aggregator_include_tagged_description">Subscribe for any event that p-tags the aggregator pubkey on its read relays</string>
     <string name="relay_aggregator_wifi_only">Pause on mobile data</string>
     <string name="relay_aggregator_wifi_only_description">Stop fetching events while the device is on mobile data or a metered Wi-Fi network. Resumes automatically on unmetered Wi-Fi.</string>
+    <string name="relay_aggregator_pause_on_limited_network">Pause on limited networks</string>
+    <string name="relay_aggregator_pause_on_limited_network_description">Stop fetching events while the device is on a network with restricted connectivity (for example a captive portal or an enterprise network that blocks general internet traffic). Resumes automatically when full connectivity returns.</string>
     <string name="relay_aggregator_phase_paused">Paused (metered network)</string>
     <string name="relay_aggregator_kinds_empty_hint">Empty list disables the aggregator subscription</string>
     <string name="relay_aggregator_extra_relays">Extra relays</string>


### PR DESCRIPTION
Adds a new on-by-default setting (relayAggregatorPauseOnLimitedNetwork)
that suspends the aggregator whenever the active network lacks
NET_CAPABILITY_NOT_RESTRICTED — e.g. captive portals or enterprise
networks. Mirrors the existing wifi-only pause path; the two toggles are
independent and OR'd together in evaluateNetworkState. The internal
pause flag and helpers are renamed from *Metered to *Network since they
now cover either condition.

https://claude.ai/code/session_01JiWLcpHMBQSpHu6VDDjyDe