### PR TITLE
Filter onion relay URLs from aggregator when outbound proxy is disabled

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -1204,6 +1204,7 @@ object RelayAggregator {
     private fun normalizeRemote(raw: String): NormalizedRelayUrl? {
         val n = RelayUrlNormalizer.normalizeOrNull(raw) ?: return null
         if (Citrine.instance.isPrivateIp(n.url)) return null
+        if (!Settings.useProxy && Citrine.instance.isOnionUrl(n.url)) return null
         return NormalizedRelayUrl(url = n.url)
     }
 


### PR DESCRIPTION
When Settings.useProxy is off the aggregator cannot reach .onion relays,
so drop them in normalizeRemote() rather than attempting doomed clearnet
connections. Covers every dynamic relay source that flows through this helper.

https://claude.ai/code/session_01EaEFYMLZEq4FS7CwDYGQrW