### PR TITLE
Fix PokeyReceiver registration race condition and unregister errors

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/Citrine.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/Citrine.kt
@@ -62,6 +62,7 @@ class Citrine : Application() {
     val client: NostrClient = NostrClient(factory, applicationScope)
 
     private val pokeyReceiver = PokeyReceiver()
+    private var isPokeyReceiverRegistered = false
 
     fun isPrivateIp(url: String): Boolean = url.contains("127.0.0.1") ||
         url.contains("localhost") ||
@@ -84,7 +85,10 @@ class Citrine : Application() {
         url.contains("172.31.")
 
     @SuppressLint("UnspecifiedRegisterReceiverFlag")
+    @Synchronized
     fun registerPokeyReceiver() {
+        if (isPokeyReceiverRegistered) return
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             registerReceiver(
                 pokeyReceiver,
@@ -97,10 +101,19 @@ class Citrine : Application() {
                 IntentFilter(PokeyReceiver.POKEY_ACTION),
             )
         }
+        isPokeyReceiverRegistered = true
     }
 
+    @Synchronized
     fun unregisterPokeyReceiver() {
-        unregisterReceiver(pokeyReceiver)
+        if (!isPokeyReceiverRegistered) return
+
+        try {
+            unregisterReceiver(pokeyReceiver)
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "PokeyReceiver was not registered", e)
+        }
+        isPokeyReceiverRegistered = false
     }
 
     override fun onCreate() {


### PR DESCRIPTION
## Summary

Fixes a race condition in `PokeyReceiver` registration/unregistration that could cause crashes or duplicate registrations. The receiver is now guarded by a state flag and synchronized methods, with proper error handling for unregistration attempts.

## Changes

- Added `isPokeyReceiverRegistered` boolean flag to track receiver registration state
- Made `registerPokeyReceiver()` and `unregisterPokeyReceiver()` synchronized to prevent concurrent access
- Added early return in `registerPokeyReceiver()` to prevent duplicate registrations
- Added early return in `unregisterPokeyReceiver()` to prevent unregistering an already-unregistered receiver
- Wrapped `unregisterReceiver()` call in try-catch to gracefully handle `IllegalArgumentException` if the receiver was not actually registered
- Added warning log when unregistration fails

## Implementation Details

The `PokeyReceiver` is a global singleton that needs careful lifecycle management. Without these guards, concurrent calls to register/unregister could cause:
- `IllegalArgumentException` when attempting to unregister a receiver that wasn't registered
- Duplicate registrations if `registerPokeyReceiver()` is called multiple times concurrently

The synchronized methods and state flag ensure idempotent behavior and thread-safe registration state tracking.

https://claude.ai/code/session_01ERmaA1Nwmfmx8Np69AVB6J