### PR TITLE
Add persistent logging with Room database

### DIFF
--- a/app/schemas/com.greenart7c3.citrine.logs.LogDatabase/1.json
+++ b/app/schemas/com.greenart7c3.citrine.logs.LogDatabase/1.json
@@ -1,0 +1,66 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "fb725986da47608fb3097d694ea9992d",
+    "entities": [
+      {
+        "tableName": "logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` INTEGER NOT NULL, `level` TEXT NOT NULL, `tag` TEXT NOT NULL, `message` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "idx_log_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_log_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'fb725986da47608fb3097d694ea9992d')"
+    ]
+  }
+}

--- a/app/src/main/java/com/greenart7c3/citrine/Citrine.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/Citrine.kt
@@ -7,8 +7,8 @@ import android.app.PendingIntent
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
-import android.util.Log
 import com.greenart7c3.citrine.database.AppDatabase
+import com.greenart7c3.citrine.logs.Log
 import com.greenart7c3.citrine.okhttp.HttpClientManager
 import com.greenart7c3.citrine.okhttp.OkHttpWebSocket
 import com.greenart7c3.citrine.server.OlderThan
@@ -120,6 +120,8 @@ class Citrine : Application() {
         super.onCreate()
 
         instance = this
+
+        Log.init(this)
 
         Thread.setDefaultUncaughtExceptionHandler(UnexpectedCrashSaver(crashReportCache, applicationScope))
 

--- a/app/src/main/java/com/greenart7c3/citrine/database/AppDatabase.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/AppDatabase.kt
@@ -2,7 +2,6 @@ package com.greenart7c3.citrine.database
 
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
-import android.util.Log
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
@@ -11,6 +10,7 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.greenart7c3.citrine.BuildConfig
 import com.greenart7c3.citrine.Citrine
+import com.greenart7c3.citrine.logs.Log
 import java.util.concurrent.Executors
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/greenart7c3/citrine/database/EventDao.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/database/EventDao.kt
@@ -1,6 +1,5 @@
 package com.greenart7c3.citrine.database
 
-import android.util.Log
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import androidx.room.Dao
@@ -11,6 +10,7 @@ import androidx.room.RawQuery
 import androidx.room.Transaction
 import androidx.sqlite.db.SupportSQLiteQuery
 import com.greenart7c3.citrine.Citrine
+import com.greenart7c3.citrine.logs.Log
 import com.greenart7c3.citrine.server.Connection
 import com.greenart7c3.citrine.server.EventSubscription
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/com/greenart7c3/citrine/logs/Log.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/logs/Log.kt
@@ -1,0 +1,125 @@
+package com.greenart7c3.citrine.logs
+
+import android.content.Context
+import com.greenart7c3.citrine.BuildConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+
+/**
+ * Drop-in replacement for [android.util.Log] that persists every log entry to a local Room
+ * database (so logs survive even on release builds where logcat output is disabled) and only
+ * forwards to the real logcat when running a debug build.
+ *
+ * Persisted logs are trimmed to the last week by [com.greenart7c3.citrine.service.WebSocketServerService].
+ */
+object Log {
+    // Integer priority constants mirroring [android.util.Log] so call sites that pass a level
+    // (e.g. isLoggable) keep working unchanged.
+    const val VERBOSE = 2
+    const val DEBUG = 3
+    const val INFO = 4
+    const val WARN = 5
+    const val ERROR = 6
+
+    private const val LEVEL_VERBOSE = "V"
+    private const val LEVEL_DEBUG = "D"
+    private const val LEVEL_INFO = "I"
+    private const val LEVEL_WARN = "W"
+    private const val LEVEL_ERROR = "E"
+
+    private const val BATCH_SIZE = 200
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    // Bounded buffer so a burst of logging on a hot path can never block callers or grow without
+    // bound. When the consumer falls behind we drop the oldest entries rather than the newest.
+    private val channel = Channel<LogEntity>(
+        capacity = 2000,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    @Volatile
+    private var dao: LogDao? = null
+
+    @Volatile
+    private var started = false
+
+    /** Wires up persistence. Safe to call multiple times; only the first call has any effect. */
+    @Synchronized
+    fun init(context: Context) {
+        if (started) return
+        started = true
+        val logDao = LogDatabase.getDatabase(context).logDao()
+        dao = logDao
+        scope.launch { consume(logDao) }
+    }
+
+    private suspend fun consume(logDao: LogDao) {
+        val buffer = ArrayList<LogEntity>(BATCH_SIZE)
+        for (first in channel) {
+            buffer.add(first)
+            // Drain anything already queued so we insert in batches instead of one row at a time.
+            while (buffer.size < BATCH_SIZE) {
+                val next = channel.tryReceive().getOrNull() ?: break
+                buffer.add(next)
+            }
+            try {
+                logDao.insertAll(buffer)
+            } catch (_: Exception) {
+                // Never let logging failures crash or spam the app.
+            }
+            buffer.clear()
+        }
+    }
+
+    private fun persist(level: String, tag: String, msg: String, tr: Throwable?) {
+        val message = if (tr != null) {
+            msg + "\n" + android.util.Log.getStackTraceString(tr)
+        } else {
+            msg
+        }
+        channel.trySend(
+            LogEntity(
+                timestamp = System.currentTimeMillis(),
+                level = level,
+                tag = tag,
+                message = message,
+            ),
+        )
+    }
+
+    /**
+     * Mirrors [android.util.Log.isLoggable]. Since logcat output only happens on debug builds,
+     * a level is only "loggable" to logcat on a debug build.
+     */
+    fun isLoggable(tag: String, level: Int): Boolean = BuildConfig.DEBUG
+
+    fun v(tag: String, msg: String, tr: Throwable? = null): Int {
+        persist(LEVEL_VERBOSE, tag, msg, tr)
+        return if (BuildConfig.DEBUG) android.util.Log.v(tag, msg, tr) else 0
+    }
+
+    fun d(tag: String, msg: String, tr: Throwable? = null): Int {
+        persist(LEVEL_DEBUG, tag, msg, tr)
+        return if (BuildConfig.DEBUG) android.util.Log.d(tag, msg, tr) else 0
+    }
+
+    fun i(tag: String, msg: String, tr: Throwable? = null): Int {
+        persist(LEVEL_INFO, tag, msg, tr)
+        return if (BuildConfig.DEBUG) android.util.Log.i(tag, msg, tr) else 0
+    }
+
+    fun w(tag: String, msg: String, tr: Throwable? = null): Int {
+        persist(LEVEL_WARN, tag, msg, tr)
+        return if (BuildConfig.DEBUG) android.util.Log.w(tag, msg, tr) else 0
+    }
+
+    fun e(tag: String, msg: String, tr: Throwable? = null): Int {
+        persist(LEVEL_ERROR, tag, msg, tr)
+        return if (BuildConfig.DEBUG) android.util.Log.e(tag, msg, tr) else 0
+    }
+}

--- a/app/src/main/java/com/greenart7c3/citrine/logs/LogDao.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/logs/LogDao.kt
@@ -1,0 +1,21 @@
+package com.greenart7c3.citrine.logs
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface LogDao {
+    @Insert
+    suspend fun insertAll(logs: List<LogEntity>)
+
+    @Query("SELECT * FROM logs ORDER BY id DESC LIMIT :limit")
+    fun getRecent(limit: Int): Flow<List<LogEntity>>
+
+    @Query("DELETE FROM logs WHERE timestamp < :timestamp")
+    suspend fun deleteOlderThan(timestamp: Long)
+
+    @Query("DELETE FROM logs")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/com/greenart7c3/citrine/logs/LogDatabase.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/logs/LogDatabase.kt
@@ -1,0 +1,32 @@
+package com.greenart7c3.citrine.logs
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [LogEntity::class],
+    version = 1,
+)
+abstract class LogDatabase : RoomDatabase() {
+    abstract fun logDao(): LogDao
+
+    companion object {
+        @Volatile
+        private var database: LogDatabase? = null
+
+        fun getDatabase(context: Context): LogDatabase = database ?: synchronized(this) {
+            database ?: Room.databaseBuilder(
+                context.applicationContext,
+                LogDatabase::class.java,
+                "citrine_logs_database",
+            )
+                .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
+                // Logs are disposable; if the schema ever changes just start fresh.
+                .fallbackToDestructiveMigration(true)
+                .build()
+                .also { database = it }
+        }
+    }
+}

--- a/app/src/main/java/com/greenart7c3/citrine/logs/LogEntity.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/logs/LogEntity.kt
@@ -1,0 +1,28 @@
+package com.greenart7c3.citrine.logs
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Entity(
+    tableName = "logs",
+    indices = [
+        Index(value = ["timestamp"], name = "idx_log_timestamp"),
+    ],
+)
+data class LogEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    // Epoch milliseconds when the log entry was created.
+    val timestamp: Long,
+    // Single-letter level: V, D, I, W or E.
+    val level: String,
+    val tag: String,
+    val message: String,
+)
+
+private val logDateFormat = SimpleDateFormat("MM-dd HH:mm:ss.SSS", Locale.US)
+
+fun LogEntity.format(): String = "${logDateFormat.format(Date(timestamp))} $level/$tag: $message"

--- a/app/src/main/java/com/greenart7c3/citrine/okhttp/EncryptedBlobInterceptor.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/okhttp/EncryptedBlobInterceptor.kt
@@ -20,7 +20,7 @@
  */
 package com.greenart7c3.citrine.okhttp
 
-import android.util.Log
+import com.greenart7c3.citrine.logs.Log
 import com.vitorpamplona.quartz.utils.ciphers.AESGCM
 import com.vitorpamplona.quartz.utils.ciphers.NostrCipher
 import okhttp3.Interceptor

--- a/app/src/main/java/com/greenart7c3/citrine/okhttp/HttpClientManager.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/okhttp/HttpClientManager.kt
@@ -20,8 +20,8 @@
  */
 package com.greenart7c3.citrine.okhttp
 
-import android.util.Log
 import com.greenart7c3.citrine.Citrine
+import com.greenart7c3.citrine.logs.Log
 import java.net.InetSocketAddress
 import java.net.Proxy
 import java.time.Duration

--- a/app/src/main/java/com/greenart7c3/citrine/okhttp/LoggingInterceptor.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/okhttp/LoggingInterceptor.kt
@@ -20,8 +20,8 @@
  */
 package com.greenart7c3.citrine.okhttp
 
-import android.util.Log
 import com.greenart7c3.citrine.Citrine
+import com.greenart7c3.citrine.logs.Log
 import java.net.InetSocketAddress
 import okhttp3.Interceptor
 import okhttp3.Request

--- a/app/src/main/java/com/greenart7c3/citrine/provider/CitrineContentProvider.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/provider/CitrineContentProvider.kt
@@ -6,13 +6,13 @@ import android.content.UriMatcher
 import android.database.Cursor
 import android.database.MatrixCursor
 import android.net.Uri
-import android.util.Log
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.EventDao
 import com.greenart7c3.citrine.database.EventWithTags
 import com.greenart7c3.citrine.database.TagEntity
 import com.greenart7c3.citrine.database.toEvent
 import com.greenart7c3.citrine.database.toEventWithTags
+import com.greenart7c3.citrine.logs.Log
 import com.greenart7c3.citrine.server.CustomWebSocketServer
 import com.greenart7c3.citrine.server.Settings
 import com.greenart7c3.citrine.service.CustomWebSocketService

--- a/app/src/main/java/com/greenart7c3/citrine/server/Connection.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Connection.kt
@@ -1,7 +1,7 @@
 package com.greenart7c3.citrine.server
 
-import android.util.Log
 import com.greenart7c3.citrine.Citrine
+import com.greenart7c3.citrine.logs.Log
 import com.vitorpamplona.negentropy.Negentropy
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import io.ktor.server.websocket.DefaultWebSocketServerSession

--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -6,7 +6,6 @@ import android.database.Cursor
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.net.Uri
-import android.util.Log
 import android.widget.Toast
 import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
@@ -24,6 +23,7 @@ import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.EventWithTags
 import com.greenart7c3.citrine.database.HistoryDatabase
 import com.greenart7c3.citrine.database.toEventWithTags
+import com.greenart7c3.citrine.logs.Log
 import com.greenart7c3.citrine.provider.CitrineContract
 import com.greenart7c3.citrine.service.CustomWebSocketService
 import com.greenart7c3.citrine.service.EventBroadcastWorker

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventRepository.kt
@@ -1,6 +1,5 @@
 package com.greenart7c3.citrine.server
 
-import android.util.Log
 import androidx.sqlite.db.SimpleSQLiteQuery
 import com.fasterxml.jackson.databind.JsonNode
 import com.greenart7c3.citrine.Citrine
@@ -8,6 +7,7 @@ import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.EventWithTags
 import com.greenart7c3.citrine.database.IdAndCreatedAt
 import com.greenart7c3.citrine.database.toEvent
+import com.greenart7c3.citrine.logs.Log
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
 import com.vitorpamplona.quartz.utils.TimeUtils

--- a/app/src/main/java/com/greenart7c3/citrine/server/EventSubscription.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/EventSubscription.kt
@@ -1,12 +1,12 @@
 package com.greenart7c3.citrine.server
 
-import android.util.Log
 import android.util.LruCache
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.EventWithTags
 import com.greenart7c3.citrine.database.toEvent
+import com.greenart7c3.citrine.logs.Log
 import com.greenart7c3.citrine.utils.isEphemeral
 import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
 import io.ktor.server.websocket.WebSocketServerSession

--- a/app/src/main/java/com/greenart7c3/citrine/server/NegentropyHandler.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/NegentropyHandler.kt
@@ -1,10 +1,10 @@
 package com.greenart7c3.citrine.server
 
-import android.util.Log
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.database.AppDatabase
+import com.greenart7c3.citrine.logs.Log
 import com.vitorpamplona.negentropy.Negentropy
 import com.vitorpamplona.negentropy.storage.StorageVector
 

--- a/app/src/main/java/com/greenart7c3/citrine/server/SubscriptionManager.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/SubscriptionManager.kt
@@ -1,7 +1,7 @@
 package com.greenart7c3.citrine.server
 
-import android.util.Log
 import com.greenart7c3.citrine.Citrine
+import com.greenart7c3.citrine.logs.Log
 import kotlin.time.measureTime
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.DelicateCoroutinesApi

--- a/app/src/main/java/com/greenart7c3/citrine/service/BootBroadcastReceiver.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/BootBroadcastReceiver.kt
@@ -4,8 +4,8 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
-import android.util.Log
 import com.greenart7c3.citrine.Citrine
+import com.greenart7c3.citrine.logs.Log
 import com.greenart7c3.citrine.server.Settings
 
 class BootBroadcastReceiver : BroadcastReceiver() {

--- a/app/src/main/java/com/greenart7c3/citrine/service/EventBroadcastWorker.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/EventBroadcastWorker.kt
@@ -1,11 +1,11 @@
 package com.greenart7c3.citrine.service
 
-import android.util.Log
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.toEvent
+import com.greenart7c3.citrine.logs.Log
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.publishAndConfirm
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl

--- a/app/src/main/java/com/greenart7c3/citrine/service/EventDownloader.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/EventDownloader.kt
@@ -4,13 +4,13 @@ import android.Manifest
 import android.app.PendingIntent
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.util.Log
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.R
+import com.greenart7c3.citrine.logs.Log
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.client.NostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.fetchFirst

--- a/app/src/main/java/com/greenart7c3/citrine/service/PokeyReceiver.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/PokeyReceiver.kt
@@ -23,8 +23,8 @@ package com.greenart7c3.citrine.service
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.util.Log
 import com.greenart7c3.citrine.Citrine
+import com.greenart7c3.citrine.logs.Log
 import com.greenart7c3.citrine.server.Settings
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -5,13 +5,13 @@ import android.content.Intent
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
-import android.util.Log
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.EventDao
 import com.greenart7c3.citrine.database.PubkeyTimestamp
 import com.greenart7c3.citrine.database.toEvent
+import com.greenart7c3.citrine.logs.Log
 import com.greenart7c3.citrine.server.Settings
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper

--- a/app/src/main/java/com/greenart7c3/citrine/service/TorManager.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/TorManager.kt
@@ -1,8 +1,8 @@
 package com.greenart7c3.citrine.service
 
-import android.util.Log
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.R
+import com.greenart7c3.citrine.logs.Log
 import com.greenart7c3.citrine.okhttp.HttpClientManager
 import com.greenart7c3.citrine.server.Settings
 import io.matthewnelson.kmp.file.readUtf8

--- a/app/src/main/java/com/greenart7c3/citrine/service/WebSocketServerService.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/WebSocketServerService.kt
@@ -11,7 +11,6 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Binder
 import android.os.IBinder
-import android.util.Log
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationChannelGroupCompat
@@ -23,6 +22,8 @@ import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.MainActivity
 import com.greenart7c3.citrine.R
 import com.greenart7c3.citrine.database.AppDatabase
+import com.greenart7c3.citrine.logs.Log
+import com.greenart7c3.citrine.logs.LogDatabase
 import com.greenart7c3.citrine.server.CustomWebSocketServer
 import com.greenart7c3.citrine.server.EventSubscription
 import com.greenart7c3.citrine.server.Settings
@@ -43,6 +44,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 
 private const val NOTIFICATION_THROTTLE_MS = 5_000L
+private const val ONE_WEEK_MILLIS = 7L * 24 * 60 * 60 * 1000
 
 class WebSocketServerService : Service() {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -86,6 +88,17 @@ class WebSocketServerService : Service() {
                     if (!Citrine.isImportingEvents) {
                         Citrine.instance.applicationScope.launch {
                             Citrine.instance.eventsToDelete(database)
+                        }
+                    }
+
+                    Citrine.instance.applicationScope.launch {
+                        try {
+                            LogDatabase.getDatabase(this@WebSocketServerService)
+                                .logDao()
+                                .deleteOlderThan(System.currentTimeMillis() - ONE_WEEK_MILLIS)
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
+                            Log.e(Citrine.TAG, "Error deleting old logs", e)
                         }
                     }
 

--- a/app/src/main/java/com/greenart7c3/citrine/ui/ContactsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/ContactsScreen.kt
@@ -1,7 +1,6 @@
 package com.greenart7c3.citrine.ui
 
 import android.app.Activity
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -37,6 +36,7 @@ import com.greenart7c3.citrine.R
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.HistoryDatabase
 import com.greenart7c3.citrine.database.toEvent
+import com.greenart7c3.citrine.logs.Log
 import com.greenart7c3.citrine.service.CustomWebSocketService
 import com.greenart7c3.citrine.utils.toDateString
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.publishAndConfirm

--- a/app/src/main/java/com/greenart7c3/citrine/ui/DownloadYourEventsUserScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/DownloadYourEventsUserScreen.kt
@@ -2,7 +2,6 @@ package com.greenart7c3.citrine.ui
 
 import android.app.Activity.RESULT_OK
 import android.content.Intent
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -59,6 +58,7 @@ import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.R
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.toEvent
+import com.greenart7c3.citrine.logs.Log
 import com.greenart7c3.citrine.service.EventDownloader
 import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
 import com.vitorpamplona.quartz.nip01Core.relay.client.auth.RelayAuthenticator

--- a/app/src/main/java/com/greenart7c3/citrine/ui/HomeScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/HomeScreen.kt
@@ -2,7 +2,6 @@ package com.greenart7c3.citrine.ui
 
 import android.app.Activity.RESULT_OK
 import android.content.Intent
-import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -51,6 +50,7 @@ import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.R
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.AppDatabase.Companion.isDatabaseUpgrading
+import com.greenart7c3.citrine.logs.Log
 import com.greenart7c3.citrine.server.Settings
 import com.greenart7c3.citrine.service.CustomWebSocketService
 import com.greenart7c3.citrine.service.LocalPreferences

--- a/app/src/main/java/com/greenart7c3/citrine/ui/HomeViewModel.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/HomeViewModel.kt
@@ -8,7 +8,6 @@ import android.content.Intent
 import android.content.ServiceConnection
 import android.content.pm.PackageManager
 import android.os.IBinder
-import android.util.Log
 import android.widget.Toast
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationChannelCompat
@@ -21,6 +20,7 @@ import com.anggrayudi.storage.file.openInputStream
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.R
 import com.greenart7c3.citrine.database.AppDatabase
+import com.greenart7c3.citrine.logs.Log
 import com.greenart7c3.citrine.server.CustomWebSocketServer
 import com.greenart7c3.citrine.service.ClipboardReceiver
 import com.greenart7c3.citrine.service.CustomWebSocketService

--- a/app/src/main/java/com/greenart7c3/citrine/ui/LogcatScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/LogcatScreen.kt
@@ -16,9 +16,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -27,7 +27,7 @@ fun LogcatScreen(
     logcatViewModel: LogcatViewModel = viewModel(),
     onClose: () -> Unit,
 ) {
-    val logMessages = logcatViewModel.logMessages.collectAsState()
+    val logMessages = logcatViewModel.logMessages.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/com/greenart7c3/citrine/ui/LogcatViewModel.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/LogcatViewModel.kt
@@ -1,53 +1,22 @@
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.greenart7c3.citrine.Citrine
-import java.io.BufferedReader
-import java.io.InputStreamReader
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import com.greenart7c3.citrine.logs.LogDatabase
+import com.greenart7c3.citrine.logs.format
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 
 private const val MAX_LOG_LINES = 500
 
 class LogcatViewModel : ViewModel() {
-    private val _logMessages = MutableStateFlow<List<String>>(emptyList())
-    val logMessages = _logMessages.asStateFlow()
+    private val logDao = LogDatabase.getDatabase(Citrine.instance).logDao()
 
-    init {
-        startCollectingLogs()
-    }
-
-    private fun startCollectingLogs() {
-        viewModelScope.launch {
-            collectLogs()
-        }
-    }
-
-    private suspend fun collectLogs() {
-        withContext(Dispatchers.IO) {
-            try {
-                // Get the process ID for the current app
-                val processId = android.os.Process.myPid()
-                // Start listening to logcat for the current app's logs continuously
-                // Include both Citrine and CitrineContentProvider tags to show ContentProvider errors
-                // Using multiple -s flags to filter by both tags
-                val process = Runtime.getRuntime().exec("logcat --pid=$processId -s ${Citrine.TAG}:* -s CitrineContentProvider:*")
-                val reader = BufferedReader(InputStreamReader(process.inputStream))
-
-                val buffer = ArrayDeque<String>()
-                reader.useLines { lines ->
-                    lines.forEach { logMessage ->
-                        buffer.addFirst(logMessage)
-                        while (buffer.size > MAX_LOG_LINES) buffer.removeLast()
-                        _logMessages.value = buffer.toList()
-                    }
-                }
-            } catch (e: Exception) {
-                Log.e("LogcatViewModel", "Error reading Logcat", e)
-            }
-        }
-    }
+    val logMessages = logDao.getRecent(MAX_LOG_LINES)
+        .map { logs -> logs.map { it.format() } }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = emptyList(),
+        )
 }

--- a/app/src/main/java/com/greenart7c3/citrine/ui/components/DatabaseInfo.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/components/DatabaseInfo.kt
@@ -1,6 +1,5 @@
 package com.greenart7c3.citrine.ui.components
 
-import android.util.Log
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -44,6 +43,7 @@ import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.R
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.EventDao
+import com.greenart7c3.citrine.logs.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.SharingStarted

--- a/app/src/main/java/com/greenart7c3/citrine/ui/settings/AggregatorSettingsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/settings/AggregatorSettingsScreen.kt
@@ -38,6 +38,7 @@ import androidx.core.net.toUri
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.R
 import com.greenart7c3.citrine.database.AppDatabase
+import com.greenart7c3.citrine.logs.Log
 import com.greenart7c3.citrine.server.Settings
 import com.greenart7c3.citrine.service.LocalPreferences
 import com.greenart7c3.citrine.service.RelayAggregator
@@ -109,7 +110,7 @@ fun AggregatorSettingsScreen(
                         aggregatorSignerPubkey = returnedKey
                         aggregatorSignerPackageName = packageName
                     } catch (e: Exception) {
-                        android.util.Log.d(Citrine.TAG, e.message ?: "", e)
+                        Log.d(Citrine.TAG, e.message ?: "", e)
                     }
                 }
             }
@@ -200,7 +201,7 @@ fun AggregatorSettingsScreen(
                                         intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
                                         aggregatorSignerLauncher.launch(intent)
                                     } catch (e: Exception) {
-                                        android.util.Log.d(Citrine.TAG, e.message ?: "", e)
+                                        Log.d(Citrine.TAG, e.message ?: "", e)
                                         Toast.makeText(
                                             context,
                                             context.getString(R.string.no_external_signer_installed),

--- a/app/src/main/java/com/greenart7c3/citrine/utils/ExportDatabaseUtils.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/utils/ExportDatabaseUtils.kt
@@ -1,7 +1,6 @@
 package com.greenart7c3.citrine.utils
 
 import android.content.Context
-import android.util.Log
 import androidx.documentfile.provider.DocumentFile
 import com.anggrayudi.storage.file.CreateMode
 import com.anggrayudi.storage.file.makeFile
@@ -9,6 +8,7 @@ import com.anggrayudi.storage.file.openOutputStream
 import com.greenart7c3.citrine.Citrine
 import com.greenart7c3.citrine.database.AppDatabase
 import com.greenart7c3.citrine.database.toEvent
+import com.greenart7c3.citrine.logs.Log
 import java.util.Date
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay

--- a/app/src/main/java/com/greenart7c3/citrine/utils/NetworkUtils.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/utils/NetworkUtils.kt
@@ -1,7 +1,7 @@
 package com.greenart7c3.citrine.utils
 
-import android.util.Log
 import com.greenart7c3.citrine.Citrine
+import com.greenart7c3.citrine.logs.Log
 import java.net.Inet4Address
 import java.net.NetworkInterface
 


### PR DESCRIPTION
## Summary

Replaces the logcat-based logging system with a persistent Room database that survives across app restarts and release builds. Logs are now stored locally and displayed in the LogcatScreen, with automatic cleanup of entries older than one week.

## Key Changes

- **New logging module** (`com.greenart7c3.citrine.logs`):
  - `Log` object: Drop-in replacement for `android.util.Log` that persists all entries to a Room database while forwarding to logcat only on debug builds
  - `LogEntity`, `LogDao`, `LogDatabase`: Room persistence layer with indexed timestamp queries
  - Bounded channel (capacity 2000, DROP_OLDEST) for non-blocking log writes with batch insertion (200 entries per transaction)
  - `LogEntity.format()` extension for consistent log formatting (MM-dd HH:mm:ss.SSS level/tag: message)

- **Updated LogcatViewModel**:
  - Replaced logcat process execution with Room database queries
  - Now observes `LogDao.getRecent(MAX_LOG_LINES)` as a Flow and formats entries for display
  - Uses `stateIn()` with WhileSubscribed sharing strategy for lifecycle-aware collection

- **WebSocketServerService**:
  - Added periodic cleanup task that deletes logs older than one week
  - Runs on app's global `applicationScope` to survive service lifecycle

- **Global Log import migration**:
  - Replaced all `android.util.Log` imports with `com.greenart7c3.citrine.logs.Log` across 20+ files
  - Maintains API compatibility (same method signatures and priority constants)

- **UI improvements**:
  - Updated `LogcatScreen` to use `collectAsStateWithLifecycle()` instead of `collectAsState()` for better lifecycle handling

## Implementation Details

- Logs are persisted asynchronously via a coroutine channel to avoid blocking callers
- Batch insertion (200 entries) reduces database write overhead during high-volume logging
- DROP_OLDEST overflow policy ensures the app never blocks or crashes due to logging
- Room schema includes an index on `timestamp` for efficient cleanup queries
- Database uses WRITE_AHEAD_LOGGING and destructive migration for schema changes (logs are disposable)
- `Log.init(context)` must be called once to wire up persistence; safe to call multiple times

https://claude.ai/code/session_01BMkgWDDvet5gLuj9wRAawe