### PR TITLE
Add rejected kinds filtering for event ingestion

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/provider/CitrineContentProvider.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/provider/CitrineContentProvider.kt
@@ -575,6 +575,9 @@ class CitrineContentProvider : ContentProvider() {
                         CustomWebSocketServer.VerificationResult.KindNotAllowed -> {
                             QueryResult.error<Uri>("Kind not allowed")
                         }
+                        CustomWebSocketServer.VerificationResult.KindRejected -> {
+                            QueryResult.error<Uri>("Kind ${event.kind} is not accepted by this relay")
+                        }
                         CustomWebSocketServer.VerificationResult.PubkeyNotAllowed -> {
                             QueryResult.error<Uri>("Pubkey not allowed")
                         }

--- a/app/src/main/java/com/greenart7c3/citrine/server/CommandResult.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CommandResult.kt
@@ -12,6 +12,7 @@ data class CommandResult(val eventId: String, val result: Boolean, val descripti
         fun ok(event: Event) = CommandResult(event.id, true)
         fun duplicated(event: Event) = CommandResult(event.id, true, "duplicate:")
         fun invalid(event: Event, message: String) = CommandResult(event.id, false, "invalid: $message")
+        fun blocked(event: Event, message: String) = CommandResult(event.id, false, "blocked: $message")
         fun required(event: Event, message: String) = CommandResult(event.id, false, "auth-required: $message")
 
         fun mute(event: Event) = CommandResult(event.id, false, "mute: no one was listening to your ephemeral event and it wasn't handled in any way, it was ignored")

--- a/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/CustomWebSocketServer.kt
@@ -360,6 +360,7 @@ class CustomWebSocketServer(
         Expired,
         Valid,
         KindNotAllowed,
+        KindRejected,
         PubkeyNotAllowed,
         TaggedPubkeyNotAllowed,
         Deleted,
@@ -378,6 +379,11 @@ class CustomWebSocketServer(
         if (event.isExpired() && connection != null) {
             Log.d(Citrine.TAG, "event expired ${event.id} ${event.expiration()}")
             return VerificationResult.Expired
+        }
+
+        if (event.kind in Settings.rejectedKinds) {
+            Log.d(Citrine.TAG, "kind rejected ${event.kind}")
+            return VerificationResult.KindRejected
         }
 
         if (Settings.allowedKinds.isNotEmpty() && event.kind !in Settings.allowedKinds) {
@@ -539,6 +545,9 @@ class CustomWebSocketServer(
             VerificationResult.KindNotAllowed -> {
                 connection?.trySend(CommandResult.invalid(event, "kind not allowed").toJson())
             }
+            VerificationResult.KindRejected -> {
+                connection?.trySend(CommandResult.blocked(event, "kind ${event.kind} is not accepted by this relay").toJson())
+            }
             VerificationResult.PubkeyNotAllowed -> {
                 connection?.trySend(CommandResult.invalid(event, "pubkey not allowed").toJson())
             }
@@ -589,6 +598,9 @@ class CustomWebSocketServer(
     private fun dTagOrEmpty(event: Event): String = event.tags.firstOrNull { it.size > 1 && it[0] == "d" }?.get(1) ?: ""
 
     private fun policyAllows(event: Event): Boolean {
+        if (event.kind in Settings.rejectedKinds) {
+            return false
+        }
         if (Settings.allowedKinds.isNotEmpty() && event.kind !in Settings.allowedKinds) {
             return false
         }

--- a/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/server/Settings.kt
@@ -5,6 +5,16 @@ import com.greenart7c3.citrine.R
 import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
 
 object Settings {
+    // Event kinds that are signed artifacts never meant to be published to a relay as
+    // standalone events. They are rejected at ingestion with an OK false "blocked:" response
+    // and never stored:
+    //   - 13    NIP-59 seal (inner layer, only valid wrapped in a gift wrap)
+    //   - 9734  NIP-57 zap request (sent to the LNURL callback, not relays)
+    //   - 22242 NIP-42 client auth (carried only in ["AUTH", ...] frames)
+    //   - 24242 Blossom (NIP-B7) blob auth (HTTP Authorization header artifact)
+    //   - 27235 NIP-98 HTTP auth (HTTP Authorization header artifact)
+    val DEFAULT_REJECTED_KINDS = setOf(13, 9734, 22242, 24242, 27235)
+
     val DEFAULT_AGGREGATOR_SOURCE_RELAYS = setOf(
         "wss://aggr.nostr.land/",
     )
@@ -25,6 +35,10 @@ object Settings {
     )
 
     var allowedKinds: Set<Int> = emptySet()
+
+    // Signed artifacts that must never be stored as standalone events (see DEFAULT_REJECTED_KINDS).
+    // Events whose kind is in this set are rejected at ingestion before any storage.
+    var rejectedKinds: Set<Int> = DEFAULT_REJECTED_KINDS
     var allowedPubKeys: Set<String> = emptySet()
     var allowedTaggedPubKeys: Set<String> = emptySet()
     var deleteEventsOlderThan: OlderThan = OlderThan.NEVER
@@ -110,6 +124,7 @@ object Settings {
 
     fun defaultValues() {
         allowedKinds = emptySet()
+        rejectedKinds = DEFAULT_REJECTED_KINDS
         allowedPubKeys = emptySet()
         allowedTaggedPubKeys = emptySet()
         deleteEventsOlderThan = OlderThan.NEVER

--- a/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/LocalPreferences.kt
@@ -8,6 +8,7 @@ import com.greenart7c3.citrine.server.Settings
 
 object PrefKeys {
     const val ALLOWED_KINDS = "allowed_kinds"
+    const val REJECTED_KINDS = "rejected_kinds"
     const val ALLOWED_PUB_KEYS = "allowed_pub_keys"
     const val ALLOWED_TAGGED_PUB_KEYS = "allowed_tagged_pub_keys"
     const val DELETE_EVENTS_OLDER_THAN = "delete_events_older_than"
@@ -68,6 +69,9 @@ object LocalPreferences {
                 } else {
                     putString(PrefKeys.ALLOWED_KINDS, settings.allowedKinds.joinToString(","))
                 }
+                // Persisted even when empty so a user who clears the defaults keeps an empty
+                // set on reload instead of having DEFAULT_REJECTED_KINDS restored.
+                putString(PrefKeys.REJECTED_KINDS, settings.rejectedKinds.joinToString(","))
                 putStringSet(PrefKeys.ALLOWED_PUB_KEYS, settings.allowedPubKeys)
                 putStringSet(PrefKeys.ALLOWED_TAGGED_PUB_KEYS, settings.allowedTaggedPubKeys)
                 putString(PrefKeys.DELETE_EVENTS_OLDER_THAN, settings.deleteEventsOlderThan.toString())
@@ -132,6 +136,11 @@ object LocalPreferences {
     fun loadSettingsFromEncryptedStorage(context: Context) {
         val prefs = encryptedPreferences(context)
         Settings.allowedKinds = prefs.getString(PrefKeys.ALLOWED_KINDS, null)?.split(",")?.mapNotNull { it.toIntOrNull() }?.toSet() ?: emptySet()
+        Settings.rejectedKinds = prefs.getString(PrefKeys.REJECTED_KINDS, null)
+            ?.split(",")
+            ?.mapNotNull { it.toIntOrNull() }
+            ?.toSet()
+            ?: Settings.DEFAULT_REJECTED_KINDS
         Settings.allowedPubKeys = prefs.getStringSet(PrefKeys.ALLOWED_PUB_KEYS, emptySet()) ?: emptySet()
         Settings.allowedTaggedPubKeys = prefs.getStringSet(PrefKeys.ALLOWED_TAGGED_PUB_KEYS, emptySet()) ?: emptySet()
         Settings.deleteEventsOlderThan = OlderThan.valueOf(prefs.getString(PrefKeys.DELETE_EVENTS_OLDER_THAN, OlderThan.NEVER.toString()) ?: OlderThan.NEVER.toString())

--- a/app/src/main/java/com/greenart7c3/citrine/ui/settings/AccessControlSettingsScreen.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/ui/settings/AccessControlSettingsScreen.kt
@@ -45,10 +45,12 @@ fun AccessControlSettingsScreen(
         var allowedPubKeys by remember { mutableStateOf(Settings.allowedPubKeys) }
         var allowedTaggedPubKeys by remember { mutableStateOf(Settings.allowedTaggedPubKeys) }
         var allowedKinds by remember { mutableStateOf(Settings.allowedKinds) }
+        var rejectedKinds by remember { mutableStateOf(Settings.rejectedKinds) }
 
         var signedBy by remember { mutableStateOf(TextFieldValue("")) }
         var referredBy by remember { mutableStateOf(TextFieldValue("")) }
         var kind by remember { mutableStateOf(TextFieldValue("")) }
+        var rejectedKind by remember { mutableStateOf(TextFieldValue("")) }
 
         val applyChanges = {
             scope.launch(Dispatchers.IO) {
@@ -57,6 +59,7 @@ fun AccessControlSettingsScreen(
                 Settings.allowedPubKeys = allowedPubKeys
                 Settings.allowedTaggedPubKeys = allowedTaggedPubKeys
                 Settings.allowedKinds = allowedKinds
+                Settings.rejectedKinds = rejectedKinds
                 LocalPreferences.saveSettingsToEncryptedStorage(Settings, context)
                 onApplyChanges()
                 delay(1500)
@@ -202,6 +205,49 @@ fun AccessControlSettingsScreen(
                     PubkeyListItem(
                         text = k.toString(),
                         onDelete = { allowedKinds = allowedKinds - k },
+                    )
+                }
+
+                stickyHeader {
+                    SectionHeader(stringResource(R.string.rejected_kinds))
+                }
+                item {
+                    PubkeyInputRow(
+                        value = rejectedKind,
+                        onValueChange = { rejectedKind = it },
+                        onPaste = {
+                            scope.launch {
+                                val text = clipboardManager.getClipEntry()?.clipData?.getItemAt(0)?.text?.toString() ?: return@launch
+                                rejectedKind = TextFieldValue(text)
+                                val k = text.toIntOrNull()
+                                if (k == null) {
+                                    Toast.makeText(context, context.getString(R.string.invalid_kind), Toast.LENGTH_SHORT).show()
+                                    return@launch
+                                }
+                                rejectedKinds = rejectedKinds + k
+                                rejectedKind = TextFieldValue("")
+                            }
+                        },
+                        onAdd = {
+                            val k = rejectedKind.text.toIntOrNull()
+                            if (k == null) {
+                                Toast.makeText(context, context.getString(R.string.invalid_kind), Toast.LENGTH_SHORT).show()
+                                return@PubkeyInputRow
+                            }
+                            rejectedKinds = rejectedKinds + k
+                            rejectedKind = TextFieldValue("")
+                        },
+                    )
+                }
+                if (rejectedKinds.isEmpty()) {
+                    item {
+                        EmptyListHint(stringResource(R.string.reject_no_kinds_hint))
+                    }
+                }
+                items(rejectedKinds.toList()) { k ->
+                    PubkeyListItem(
+                        text = k.toString(),
+                        onDelete = { rejectedKinds = rejectedKinds - k },
                     )
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,7 @@
     <string name="accept_events_that_refer_to">Accept events that refer to</string>
     <string name="add">Add</string>
     <string name="allowed_kinds">Allowed kinds</string>
+    <string name="rejected_kinds">Rejected kinds</string>
     <string name="invalid_kind">Invalid kind</string>
     <string name="others">Others</string>
     <string name="never_delete_from">Never delete from</string>
@@ -109,6 +110,7 @@
     <string name="allow_all_pubkeys_hint">Empty list allows events from all pubkeys</string>
     <string name="allow_all_tagged_pubkeys_hint">Empty list allows events referencing any pubkey</string>
     <string name="allow_all_kinds_hint">Empty list allows all event kinds</string>
+    <string name="reject_no_kinds_hint">Empty list rejects no kinds. Listed kinds are rejected at ingestion and never stored — defaults block signed artifacts that aren\'t meant to be published (seals, zap requests, auth events).</string>
     <string name="start_on_boot_description">Automatically start the relay when the device boots</string>
     <string name="enable_disable_auth_description">Require NIP-42 authentication for private event kinds</string>
     <string name="listen_to_pokey_broadcasts_description">Receive events broadcast by the Pokey app</string>


### PR DESCRIPTION
## Summary
Adds support for rejecting specific event kinds at ingestion time, preventing them from being stored in the relay. This complements the existing allowlist-based `allowedKinds` filtering with a blocklist-based approach, useful for filtering out signed artifacts that should never be published as standalone events.

## Key Changes

- **Settings & Defaults**: Added `rejectedKinds` setting with sensible defaults (`DEFAULT_REJECTED_KINDS`) that block kinds 13 (NIP-59 seals), 9734 (NIP-57 zap requests), 22242 (NIP-42 auth), 24242 (Blossom auth), and 27235 (NIP-98 HTTP auth). These are artifacts designed to be wrapped or transmitted via other channels, not stored as relay events.

- **Event Verification**: Updated `CustomWebSocketServer.verifyEvent()` to check `rejectedKinds` before `allowedKinds`, returning a new `VerificationResult.KindRejected` status. Rejected events receive a `blocked:` response per NIP-01 rather than `invalid:`.

- **Policy Enforcement**: Added `rejectedKinds` check to `policyAllows()` to prevent rejected kinds from being queried or returned to subscribers.

- **Persistence**: Added `REJECTED_KINDS` preference key and serialization logic in `LocalPreferences`. The setting is always persisted (even when empty) so users who clear defaults don't get them restored on reload.

- **UI**: Added "Rejected kinds" section to `AccessControlSettingsScreen` with input/paste/add/delete controls mirroring the "Allowed kinds" UI. Includes a hint explaining the purpose and defaults.

- **Error Handling**: Updated `CitrineContentProvider` to handle `KindRejected` verification results with appropriate error messages.

- **Protocol**: Added `CommandResult.blocked()` factory method to generate NIP-01 compliant `blocked:` responses for rejected events.

## Implementation Details

- Rejected kinds are checked **before** allowed kinds in the verification pipeline, ensuring blocklist takes precedence over allowlist.
- Default rejected kinds are only restored if the preference is missing; an empty persisted set is respected.
- The UI hint clarifies that rejected kinds are "signed artifacts that aren't meant to be published" to help users understand the distinction from allowlist filtering.

https://claude.ai/code/session_014Qz34gnXqNCmQnmAyVS6D5