### PR TITLE
Remove damus.io from fallback outbox relays

### DIFF
--- a/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
+++ b/app/src/main/java/com/greenart7c3/citrine/service/RelayAggregator.kt
@@ -80,7 +80,6 @@ object RelayAggregator {
     private const val TAG = "RelayAggregator"
 
     private val FALLBACK_OUTBOX_RELAYS = listOf(
-        RelayUrlNormalizer.normalize("wss://relay.damus.io/"),
         RelayUrlNormalizer.normalize("wss://nos.lol/"),
         RelayUrlNormalizer.normalize("wss://relay.primal.net/"),
     )


### PR DESCRIPTION
## Summary
Removes `wss://relay.damus.io/` from the fallback outbox relay list in `RelayAggregator`.

## Changes
- Removed `RelayUrlNormalizer.normalize("wss://relay.damus.io/")` from the `FALLBACK_OUTBOX_RELAYS` list
- The fallback relay list now contains only `nos.lol` and `relay.primal.net`

## Details
This change reduces the set of default relays used for broadcasting events when no user-configured relays are available. The damus.io relay is no longer included as a fallback option.

https://claude.ai/code/session_01TiPfw8RDgztGy9agLVwykr